### PR TITLE
fix: hydration errors and incorrect block #s

### DIFF
--- a/app/puzzle/[id]/(components)/info/solution-form/index.tsx
+++ b/app/puzzle/[id]/(components)/info/solution-form/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type FC, useState } from 'react';
+import { type FC, useEffect, useState } from 'react';
 
 import PuzzleInfoSolutionFormOptionsForm from './options-form';
 import PuzzleInfoSolutionFormTipForm from './tip-form';
@@ -41,9 +41,13 @@ const PuzzleInfoSolutionForm: FC<PuzzleInfoSolutionFormProps> = ({ puzzle }) => 
   const [simulateTx, setSimulateTx] = useState<boolean>(true);
   const [isTipFormOpen, setIsTipFormOpen] = useState<boolean>(false);
   const [isOptionsFormOpen, setIsOptionsFormOpen] = useState<boolean>(false);
+  const [mounted, setMounted] = useState<boolean>(false);
   const { toast } = useToast();
   const { chain } = useNetwork();
   const { switchNetwork } = useSwitchNetwork();
+
+  // Set `mounted` to true on page load
+  useEffect(() => setMounted(true), []);
 
   const { config } = usePrepareContractWrite({
     address: process.env.NEXT_PUBLIC_CURTA_ADDRESS,
@@ -217,7 +221,7 @@ const PuzzleInfoSolutionForm: FC<PuzzleInfoSolutionFormProps> = ({ puzzle }) => 
           </Popover>
         </div>
       </div>
-      {!chain ? (
+      {!chain || !mounted ? (
         <ConnectButton className="w-full" />
       ) : chain.id !== Number(process.env.NEXT_PUBLIC_CHAIN_ID) ? (
         <Button

--- a/app/puzzle/[id]/(components)/info/time-left/countdown.tsx
+++ b/app/puzzle/[id]/(components)/info/time-left/countdown.tsx
@@ -3,7 +3,7 @@
 import { type FC, useEffect, useState } from 'react';
 
 import type { Phase } from '@/lib/types/protocol';
-import { getTimeLeftString } from '@/lib/utils';
+import { getPuzzleTimeLeft, getTimeLeftString } from '@/lib/utils';
 
 // -----------------------------------------------------------------------------
 // Props
@@ -11,7 +11,7 @@ import { getTimeLeftString } from '@/lib/utils';
 
 type PuzzleInfoTimeLeftCountdownProps = {
   phase: Phase;
-  timeLeft: number;
+  firstSolveTimestamp: number;
 };
 
 // -----------------------------------------------------------------------------
@@ -20,8 +20,9 @@ type PuzzleInfoTimeLeftCountdownProps = {
 
 const PuzzleInfoTimeLeftCountdown: FC<PuzzleInfoTimeLeftCountdownProps> = ({
   phase,
-  timeLeft: timePassed,
+  firstSolveTimestamp,
 }) => {
+  const timePassed = getPuzzleTimeLeft(firstSolveTimestamp).timeLeft;
   const totalTime = [0, 172_800, 259_200, 0][phase];
   const [mounted, setMounted] = useState<boolean>(false);
   const [timeLeft, setTimeLeft] = useState<number>(totalTime - timePassed);

--- a/app/puzzle/[id]/(components)/info/time-left/index.tsx
+++ b/app/puzzle/[id]/(components)/info/time-left/index.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react';
 
 import PuzzleInfoTimeLeftAccordion from './accordion';
 import PuzzleInfoTimeLeftCountdown from './countdown';
+import PuzzleInfoTimeLeftTimeline from './timeline';
 import { ArrowUpRight, Box } from 'lucide-react';
 
 import type { Puzzle } from '@/lib/types/protocol';
@@ -20,35 +21,16 @@ type PuzzleInfoTimeLeftProps = {
 // -----------------------------------------------------------------------------
 
 const PuzzleInfoTimeLeft: FC<PuzzleInfoTimeLeftProps> = ({ puzzle }) => {
-  const { phase, timeLeft } = getPuzzleTimeLeft(puzzle.firstSolveTimestamp);
-
-  const COLORS = { PHASE_0: '#22C55E', PHASE_1: '#FACC15', PHASE_2: '#F97316', PHASE_3: '#EF4444' };
-
-  // The height of the unfilled portion of the timeline, adjusting for the small
-  // gaps between the end of segments between circles and the circles. Note that
-  // we don't render any portion of the unfilled timeline when `phase === 3`, so
-  // the expression below assumes `phase` is bounded to `[0, 2]`. Helpful notes:
-  //     * `Math.sqrt(35)` is the `y` coordinate of the circle when `x = 1`:
-  //       `y**2 + x**2 = 6**2 => y = sqrt(35)`. Then, since the radius of each
-  //       circle is 6, the aforementioned "small gaps" are each `sqrt(35)`
-  //       pixels tall.
-  //     * 44 is the height of the Phase 2-3 track, through the Phase 2 circle:
-  //       `44 = (6 - sqrt(35)) + 32 + 12 - (6 - sqrt(35))`.
-  //     * `44 - 2 * sqrt(35)` is the height of the portion of the track in
-  //       in between 2 Phase indicator circles, given by
-  //       `32 + 2 * (6 - sqrt(35))`.
-  const unfilledTimelineHeight =
-    phase === 2
-      ? (44 - 2 * Math.sqrt(35)) * (1 - timeLeft / 259_200)
-      : phase === 1
-      ? 44 + (44 - 2 * Math.sqrt(35)) * (1 - timeLeft / 172_800)
-      : 132 - 2 * Math.sqrt(35); // Entire thing is filled if `phase === 0`.
+  const { phase } = getPuzzleTimeLeft(puzzle.firstSolveTimestamp);
 
   return (
     <div className="flex grow flex-col items-center gap-2 p-4">
       <div className="group relative flex w-full flex-col items-center justify-center rounded-lg bg-gray-350 py-2.5">
         <div className="text-center text-sm font-book text-gray-150">Time Left</div>
-        <PuzzleInfoTimeLeftCountdown phase={phase} timeLeft={timeLeft} />
+        <PuzzleInfoTimeLeftCountdown
+          phase={phase}
+          firstSolveTimestamp={puzzle.firstSolveTimestamp}
+        />
       </div>
       {/* We need a wrapper here because the accordion requires client-side
       interactions/hooks. */}
@@ -56,12 +38,24 @@ const PuzzleInfoTimeLeft: FC<PuzzleInfoTimeLeftProps> = ({ puzzle }) => {
         <div className="flex w-full gap-2.5 rounded-b-lg border-x border-b border-gray-300 p-4">
           <div className="flex w-1/2 flex-col items-end gap-7 pt-0.5">
             {[
-              { blockNumber: puzzle.addedBlock, disabled: false },
-              { blockNumber: puzzle.firstSolveBlock, disabled: phase < 1 },
-              { blockNumber: (puzzle.firstSolveBlock ?? 0) + 14_400, disabled: phase < 2 },
-              { blockNumber: (puzzle.firstSolveBlock ?? 0) + 21_600, disabled: phase < 3 },
-            ].map(({ blockNumber, disabled }) =>
-              blockNumber && !disabled ? (
+              { blockNumber: puzzle.addedBlock, disabled: false, hidden: false },
+              {
+                blockNumber: puzzle.firstSolveBlock ?? 0,
+                disabled: phase < 1,
+                hidden: !puzzle.firstSolveBlock,
+              },
+              {
+                blockNumber: (puzzle.firstSolveBlock ?? 0) + 14_400,
+                disabled: phase < 2,
+                hidden: !puzzle.firstSolveBlock,
+              },
+              {
+                blockNumber: (puzzle.firstSolveBlock ?? 0) + 21_600,
+                disabled: phase < 3,
+                hidden: !puzzle.firstSolveBlock,
+              },
+            ].map(({ blockNumber, disabled, hidden }) =>
+              !disabled && !hidden ? (
                 <a
                   key={blockNumber}
                   className="flex h-4 items-center gap-0.5 text-xs text-gray-100 hover:underline"
@@ -82,93 +76,13 @@ const PuzzleInfoTimeLeft: FC<PuzzleInfoTimeLeftProps> = ({ puzzle }) => {
                   <span>
                     <Box className="h-2.5 w-2.5" />
                   </span>
-                  <span>{blockNumber ?? '—'}</span>
+                  <span>{!hidden ? blockNumber : '–'}</span>
                 </span>
               ),
             )}
           </div>
           <div className="w-3">
-            <svg
-              width={12}
-              height={168}
-              viewBox="0 0 12 168"
-              role="figure"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <defs>
-                {/* Gradient for the filled portion of the timeline with stops
-                to lead into each of the circles properly (i.e. each "gradient"
-                portion completely stops and resumes before/after encountering a
-                circle's boundary). */}
-                <linearGradient id="0" gradientTransform="rotate(90)">
-                  {/* Circle 1 middle. */}
-                  <stop offset={0} stop-color={COLORS.PHASE_0} />
-                  {/* Circle 1 end. */}
-                  <stop offset={6 / 132} stop-color={COLORS.PHASE_0} />
-                  <stop offset={6 / 132} stop-color={COLORS.PHASE_0} />
-                  {/* Circle 2 start. */}
-                  <stop offset={38 / 132} stop-color={COLORS.PHASE_1} />
-                  <stop offset={38 / 132} stop-color={COLORS.PHASE_1} />
-                  {/* Circle 2 end. */}
-                  <stop offset={50 / 132} stop-color={COLORS.PHASE_1} />
-                  <stop offset={50 / 132} stop-color={COLORS.PHASE_1} />
-                  {/* Circle 3 start. */}
-                  <stop offset={82 / 132} stop-color={COLORS.PHASE_2} />
-                  <stop offset={82 / 132} stop-color={COLORS.PHASE_2} />
-                  {/* Circle 3 end. */}
-                  <stop offset={94 / 132} stop-color={COLORS.PHASE_2} />
-                  <stop offset={94 / 132} stop-color={COLORS.PHASE_2} />
-                  {/* Circle 4 start. */}
-                  <stop offset={126 / 132} stop-color={COLORS.PHASE_3} />
-                  <stop offset={126 / 132} stop-color={COLORS.PHASE_3} />
-                  {/* Circle 4 middle. */}
-                  <stop offset={1} stop-color={COLORS.PHASE_3} />
-                </linearGradient>
-              </defs>
-              {/* Filled portion of the timeline. We position both of the
-              following portions of the timeline at x={5} because we want them
-              horizontally centered.*/}
-              <rect x={5} y={10} width={2} height={132} fill="url(#0)" />
-              {/* Unfilled portion of the timeline. We position the rectangle at
-              `y={142 - Math.sqrt(35) - unfilledTimelineHeight}` because we want
-              it offset by both the height of the filled portion of the timeline
-              (given by `132 - 2 * sqrt(35) - unfilledTimelineHeight`) and the
-              top padding required to render it starting from the end of the
-              first circle (with the small gap adjustment), which is given by
-              `10 + 6 - (6 - sqrt(35)) = 10 + sqrt(35)`. Altogether, we have the
-              following sum for the `y` coordinate:
-              `132 - 2 * sqrt(35) + 10 + sqrt(35) - unfilledTimelineHeight = 142 - sqrt(35) - unfilledTimelineHeight`.
-              Note that we don't render any unfilled portion if `phase >= 3`
-              because this means the puzzle is over. */}
-              {phase < 3 ? (
-                <rect
-                  className="fill-gray-350"
-                  width={2}
-                  height={unfilledTimelineHeight}
-                  x={5}
-                  y={142 - Math.sqrt(35) - unfilledTimelineHeight}
-                />
-              ) : null}
-              <circle className="fill-tw-green" cx={6} cy={10} r={6} />
-              <circle
-                className={phase > 0 ? 'fill-tw-yellow' : 'fill-gray-350'}
-                cx={6}
-                cy={54}
-                r={6}
-              />
-              <circle
-                className={phase > 1 ? 'fill-tw-orange' : 'fill-gray-350'}
-                cx={6}
-                cy={98}
-                r={6}
-              />
-              <circle
-                className={phase > 2 ? 'fill-tw-red' : 'fill-gray-350'}
-                cx={6}
-                cy={142}
-                r={6}
-              />
-            </svg>
+            <PuzzleInfoTimeLeftTimeline firstSolveTimestamp={puzzle.firstSolveTimestamp} />
           </div>
           <div className="flex w-full flex-col gap-2">
             {[

--- a/app/puzzle/[id]/(components)/info/time-left/timeline.tsx
+++ b/app/puzzle/[id]/(components)/info/time-left/timeline.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { type FC, useEffect, useState } from 'react';
+
+import { getPuzzleTimeLeft } from '@/lib/utils';
+
+// -----------------------------------------------------------------------------
+// Props
+// -----------------------------------------------------------------------------
+
+type PuzzleInfoTimeLeftTimelineProps = {
+  firstSolveTimestamp: number;
+};
+
+// -----------------------------------------------------------------------------
+// Component
+// -----------------------------------------------------------------------------
+
+const PuzzleInfoTimeLeftTimeline: FC<PuzzleInfoTimeLeftTimelineProps> = ({
+  firstSolveTimestamp,
+}) => {
+  const [mounted, setMounted] = useState<boolean>(false);
+
+  // Set `mounted` to true on page load
+  useEffect(() => setMounted(true), []);
+
+  const COLORS = { PHASE_0: '#22C55E', PHASE_1: '#FACC15', PHASE_2: '#F97316', PHASE_3: '#EF4444' };
+
+  const { phase, timeLeft } = getPuzzleTimeLeft(firstSolveTimestamp);
+
+  // The height of the unfilled portion of the timeline, adjusting for the small
+  // gaps between the end of segments between circles and the circles. Note that
+  // we don't render any portion of the unfilled timeline when `phase === 3`, so
+  // the expression below assumes `phase` is bounded to `[0, 2]`. Helpful notes:
+  //     * `Math.sqrt(35)` is the `y` coordinate of the circle when `x = 1`:
+  //       `y**2 + x**2 = 6**2 => y = sqrt(35)`. Then, since the radius of each
+  //       circle is 6, the aforementioned "small gaps" are each `sqrt(35)`
+  //       pixels tall.
+  //     * 44 is the height of the Phase 2-3 track, through the Phase 2 circle:
+  //       `44 = (6 - sqrt(35)) + 32 + 12 - (6 - sqrt(35))`.
+  //     * `44 - 2 * sqrt(35)` is the height of the portion of the track in
+  //       in between 2 Phase indicator circles, given by
+  //       `32 + 2 * (6 - sqrt(35))`.
+  const unfilledTimelineHeight = mounted
+    ? phase === 2
+      ? (44 - 2 * Math.sqrt(35)) * (1 - timeLeft / 259_200)
+      : phase === 1
+      ? 44 + (44 - 2 * Math.sqrt(35)) * (1 - timeLeft / 172_800)
+      : 132 - 2 * Math.sqrt(35) // Fill completely if `phase === 0`.
+    : 132 - 2 * Math.sqrt(35); // Fill completely if component is unmounted.
+
+  return (
+    <svg
+      width={12}
+      height={168}
+      viewBox="0 0 12 168"
+      role="figure"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <defs>
+        {/* Gradient for the filled portion of the timeline with stops to lead
+        into each of the circles properly (i.e. each "gradient" portion
+        completely stops and resumes before/after encountering a circle's
+        boundary). */}
+        <linearGradient id="0" gradientTransform="rotate(90)">
+          {/* Circle 1 middle. */}
+          <stop offset={0} stop-color={COLORS.PHASE_0} />
+          {/* Circle 1 end. */}
+          <stop offset={6 / 132} stop-color={COLORS.PHASE_0} />
+          <stop offset={6 / 132} stop-color={COLORS.PHASE_0} />
+          {/* Circle 2 start. */}
+          <stop offset={38 / 132} stop-color={COLORS.PHASE_1} />
+          <stop offset={38 / 132} stop-color={COLORS.PHASE_1} />
+          {/* Circle 2 end. */}
+          <stop offset={50 / 132} stop-color={COLORS.PHASE_1} />
+          <stop offset={50 / 132} stop-color={COLORS.PHASE_1} />
+          {/* Circle 3 start. */}
+          <stop offset={82 / 132} stop-color={COLORS.PHASE_2} />
+          <stop offset={82 / 132} stop-color={COLORS.PHASE_2} />
+          {/* Circle 3 end. */}
+          <stop offset={94 / 132} stop-color={COLORS.PHASE_2} />
+          <stop offset={94 / 132} stop-color={COLORS.PHASE_2} />
+          {/* Circle 4 start. */}
+          <stop offset={126 / 132} stop-color={COLORS.PHASE_3} />
+          <stop offset={126 / 132} stop-color={COLORS.PHASE_3} />
+          {/* Circle 4 middle. */}
+          <stop offset={1} stop-color={COLORS.PHASE_3} />
+        </linearGradient>
+      </defs>
+      {/* Filled portion of the timeline. We position both of the following
+      portions of the timeline at x={5} because we want them horizontally
+      centered.*/}
+      <rect x={5} y={10} width={2} height={132} fill="url(#0)" />
+      {/* Unfilled portion of the timeline. We position the rectangle at
+      `y={142 - Math.sqrt(35) - unfilledTimelineHeight}` because we want it
+      offset by both the height of the filled portion of the timeline (given by
+      `132 - 2 * sqrt(35) - unfilledTimelineHeight`) and the top padding
+      required to render it starting from the end of the first circle (with the
+      small gap adjustment), which is given by
+      `10 + 6 - (6 - sqrt(35)) = 10 + sqrt(35)`. Altogether, we have the
+      following sum for the `y` coordinate:
+      `132 - 2 * sqrt(35) + 10 + sqrt(35) - unfilledTimelineHeight = 142 - sqrt(35) - unfilledTimelineHeight`.
+      Note that we don't render any unfilled portion if `phase >= 3` because
+      this means the puzzle is over. */}
+      {phase < 3 ? (
+        <rect
+          className="fill-gray-350"
+          width={2}
+          height={unfilledTimelineHeight}
+          x={5}
+          y={142 - Math.sqrt(35) - unfilledTimelineHeight}
+        />
+      ) : null}
+      <circle className="fill-tw-green" cx={6} cy={10} r={6} />
+      <circle className={phase > 0 ? 'fill-tw-yellow' : 'fill-gray-350'} cx={6} cy={54} r={6} />
+      <circle className={phase > 1 ? 'fill-tw-orange' : 'fill-gray-350'} cx={6} cy={98} r={6} />
+      <circle className={phase > 2 ? 'fill-tw-red' : 'fill-gray-350'} cx={6} cy={142} r={6} />
+    </svg>
+  );
+};
+
+export default PuzzleInfoTimeLeftTimeline;


### PR DESCRIPTION
- hides phase 2/3 block numbers if there's no first solve (instead of the incorrectly computed 14_400 and 21_600 values)
- fixes hydration errors:
  1. timeline is rendered to be completely filled until component is mounted
  2. the submit button always displays connect wallet until component is mounted