### PR TITLE
fix: fetch `lastUpdated`, so it gets cached correctly

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,6 +7,9 @@ NEXT_PUBLIC_BLOCK_EXPLORER="waterfall.constellationexplorer.xyz"
 # 1 (mainnet) | 5 (Goerli) | 17 (Constellation)
 NEXT_PUBLIC_CHAIN_ID="1"
 
+# Site Base URL
+NEXT_PUBLIC_BASE_URL=""
+
 # API key used internally by the site
 CURTA_SITE_API_KEY=""
 

--- a/app/api/now/route.ts
+++ b/app/api/now/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json({ now: Date.now() }, { status: 200 });
+}

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -17,7 +17,7 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    await revalidatePath(pathToRevalidate);
+    revalidatePath(pathToRevalidate);
     return NextResponse.json({ revalidated: true }, { status: 200 });
   } catch (err) {
     return NextResponse.json({ message: 'Error validating.' }, { status: 500 });

--- a/app/leaderboard/(components)/revalidate/index.tsx
+++ b/app/leaderboard/(components)/revalidate/index.tsx
@@ -38,13 +38,13 @@ export const LeaderboardRevalidate: FC<LeaderboardRevalidateProps> = ({ lastUpda
               description: 'Leaderboard may only be updated every minute.',
             });
           } else {
-            revalidateData();
             toast({
               intent: 'success',
               title: 'Leaderboard refreshed',
               description: 'Data will be updated momentarily!',
             });
           }
+          revalidateData(lastUpdated);
         }}
       >
         Refresh

--- a/app/leaderboard/(components)/revalidate/server-action.ts
+++ b/app/leaderboard/(components)/revalidate/server-action.ts
@@ -2,6 +2,8 @@
 
 import { revalidatePath } from 'next/cache';
 
-export default async function action() {
-  revalidatePath('/leaderboard');
+export default async function action(lastUpdated: Date) {
+  if (lastUpdated.getTime() <= Date.now() - 60_000) {
+    revalidatePath('/leaderboard');
+  }
 }

--- a/environment.d.ts
+++ b/environment.d.ts
@@ -4,6 +4,7 @@ declare global {
       // Site config
       NEXT_PUBLIC_BLOCK_EXPLORER: string;
       NEXT_PUBLIC_CHAIN_ID: 1 | 5 | 17;
+      NEXT_PUBLIC_BASE_URL: string;
       CURTA_SITE_API_KEY: string;
       // Chain config
       NEXT_PUBLIC_CURTA_ADDRESS: `0x${string}`;

--- a/lib/utils/fetchPuzzlesCount.ts
+++ b/lib/utils/fetchPuzzlesCount.ts
@@ -9,14 +9,21 @@ type PuzzlesCountResponse = {
 };
 
 const fetchPuzzlesCount = async (): Promise<PuzzlesCountResponse> => {
+  // We fetch this so the request gets cached.
+  const lastUpdated = await fetch(
+    `${process.env.NEXT_PUBLIC_BASE_URL ?? 'https://curta.wtf'}/api/now`,
+  )
+    .then((res) => res.json())
+    .then((res) => res.now);
+
   // Fetch puzzles.
   const { data, status, error } = await supabase.from('puzzles').select('id').returns<number[]>();
 
   if ((error && status !== 406) || !data || (data && data.length === 0)) {
-    return { data: { count: 0, lastUpdated: Date.now() }, status, error };
+    return { data: { count: 0, lastUpdated }, status, error };
   }
 
-  return { data: { count: data.length, lastUpdated: Date.now() }, status, error };
+  return { data: { count: data.length, lastUpdated }, status, error };
 };
 
 export default fetchPuzzlesCount;


### PR DESCRIPTION
- Fixes issue where `lastUpdated` was computed at page load (`Date.now()` doesn't get cached)
- Checks whether the data has been stale for >1 minute on the server (via the server action), as well as on the client