### PR TITLE
feat: add redirects

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -2,16 +2,17 @@ import { type NextRequest, NextResponse } from 'next/server';
 
 // This function can be marked `async` if using `await` inside
 export function middleware(request: NextRequest) {
-  if (request.nextUrl.pathname === '/docs/intro') {
+  if (request.nextUrl.pathname === '/docs/overview') {
     return NextResponse.redirect(new URL('/docs', request.url));
-  }
-
-  if (request.nextUrl.pathname === '/guides') {
-    return NextResponse.redirect(new URL('/guides/player/getting-started', request.url));
+  } else if (request.nextUrl.pathname === '/docs/puzzles') {
+    return NextResponse.redirect(new URL('/docs/puzzles/overview', request.url));
+  } else if (request.nextUrl.pathname === '/attend') {
+    // Temporary redirect to Curta Cup form
+    return NextResponse.redirect(new URL('https://forms.gle/kYLwBqWSFc59efoc7', request.url));
   }
 }
 
 // See "Matching Paths" below to learn more
 export const config = {
-  matcher: ['/docs/intro', '/guides'],
+  matcher: ['/docs/overview', '/docs/puzzles', '/attend'],
 };


### PR DESCRIPTION
# Description
- Removes `/docs/intro` $\rightarrow$ `/docs` redirect
- Removes `/guides` $\rightarrow$ `/guides/player/getting-started` redirect
- Adds `/docs/overview` $\rightarrow$ `/docs` redirect
- Adds `/docs/puzzles` $\rightarrow$ `/docs/puzzles/overview` redirect
- Adds [temporary] `/attend` $\rightarrow$ [event-specific link] (in this case, form to apply to Curta Cup 2023) redirect