### PR TITLE
Replace hard-coded block explorer link with dynamic `getBlockExplorerDomain`

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,8 +2,6 @@
 # Site config
 ################################################################################
 
-NEXT_PUBLIC_BLOCK_EXPLORER="waterfall.constellationexplorer.xyz"
-
 # Site Base URL
 NEXT_PUBLIC_BASE_URL=""
 

--- a/app/(components)/author-avatar.tsx
+++ b/app/(components)/author-avatar.tsx
@@ -3,6 +3,7 @@
 import type { FC, KeyboardEventHandler, ReactNode } from 'react';
 
 import type { Author } from '@/lib/types/protocol';
+import { getBlockExplorerDomain } from '@/lib/utils';
 
 // ---------------------------------------–-------------------------------------
 // Props
@@ -21,7 +22,7 @@ type AuthorAvatarProps = {
 const AuthorAvatar: FC<AuthorAvatarProps> = ({ author, index, children }) => {
   const href = author.twitter
     ? `https://twitter.com/${author.twitter}`
-    : `https://${process.env.NEXT_PUBLIC_BLOCK_EXPLORER}/address/${author.address}`;
+    : `https://${getBlockExplorerDomain(1)}/address/${author.address}`;
 
   const onKeyDown: KeyboardEventHandler<HTMLButtonElement> = (e) => {
     if (e.key === 'ArrowLeft' && index > 0) {

--- a/app/(components)/authors-display.tsx
+++ b/app/(components)/authors-display.tsx
@@ -79,7 +79,7 @@ const AuthorsDisplay: FC<AuthorsDisplayProps> = ({ data }) => {
                   </div>
                   <div className="ml-3.5 grow">
                     <div className="text-gray-100">{displayName}</div>
-                    <AddressLink className="w-fit text-sm" address={author.address} />
+                    <AddressLink className="w-fit text-sm" address={author.address} chainId={1} />
                   </div>
                   <div className="flex items-center gap-2">
                     {author.twitter ? (

--- a/app/(components)/links-display.tsx
+++ b/app/(components)/links-display.tsx
@@ -18,6 +18,7 @@ const LinksDisplay: FC = () => {
         </PillLinkButton>
         <PillLinkButton
           site="etherscan"
+          // Always show Curta Puzzles on Ethereum
           href={`https://${getBlockExplorerDomain(1)}/address/${
             process.env.NEXT_PUBLIC_CURTA_ADDRESS
           }`}

--- a/app/(components)/links-display.tsx
+++ b/app/(components)/links-display.tsx
@@ -1,6 +1,6 @@
 import { type FC, useId } from 'react';
 
-import { getShortenedAddress } from '@/lib/utils';
+import { getBlockExplorerDomain, getShortenedAddress } from '@/lib/utils';
 
 import PillLinkButton from '@/components/templates/pill-link-button';
 
@@ -18,7 +18,9 @@ const LinksDisplay: FC = () => {
         </PillLinkButton>
         <PillLinkButton
           site="etherscan"
-          href={`https://${process.env.NEXT_PUBLIC_BLOCK_EXPLORER}/address/${process.env.NEXT_PUBLIC_CURTA_ADDRESS}`}
+          href={`https://${getBlockExplorerDomain(1)}/address/${
+            process.env.NEXT_PUBLIC_CURTA_ADDRESS
+          }`}
         >
           {getShortenedAddress(process.env.NEXT_PUBLIC_CURTA_ADDRESS)}
         </PillLinkButton>

--- a/app/(components)/puzzles-table.tsx
+++ b/app/(components)/puzzles-table.tsx
@@ -106,7 +106,7 @@ const PuzzleTableDesktop: FC<PuzzleTableInternalProps> = ({ data, sorting, setSo
                     e.stopPropagation();
                     window.open(row.original.solution, '_blank');
                   }}
-                  aria-label={`View puzzle #${row.original.id}'s solution.`}
+                  aria-label={`View chain ${row.original.chainId} puzzle #${row.original.id}'s solution.`}
                 >
                   <FileCheck />
                 </IconButton>
@@ -127,7 +127,7 @@ const PuzzleTableDesktop: FC<PuzzleTableInternalProps> = ({ data, sorting, setSo
                       '_blank',
                     );
                   }}
-                  aria-label={`View puzzle #${row.original.id}'s contract.`}
+                  aria-label={`View chain ${row.original.chainId} puzzle #${row.original.id}'s contract.`}
                 >
                   <ExternalLink />
                 </IconButton>

--- a/app/(components)/puzzles-table.tsx
+++ b/app/(components)/puzzles-table.tsx
@@ -8,7 +8,7 @@ import type { ColumnDef, Row, SortingState } from '@tanstack/react-table';
 import { ExternalLink, FileCheck } from 'lucide-react';
 
 import type { Puzzle } from '@/lib/types/protocol';
-import { getPuzzleTimeLeft } from '@/lib/utils';
+import { getBlockExplorerDomain, getPuzzleTimeLeft } from '@/lib/utils';
 
 import AddressLinkClient from '@/components/templates/address-link-client';
 import Stat from '@/components/templates/stat';
@@ -115,11 +115,15 @@ const PuzzleTableDesktop: FC<PuzzleTableInternalProps> = ({ data, sorting, setSo
                 <IconButton
                   variant="outline"
                   intent="neutral"
-                  title={`https://${process.env.NEXT_PUBLIC_BLOCK_EXPLORER}/address/${row.original.address}`}
+                  title={`https://${getBlockExplorerDomain(row.original.chainId)}/address/${
+                    row.original.address
+                  }`}
                   onClick={(e) => {
                     e.stopPropagation();
                     window.open(
-                      `https://${process.env.NEXT_PUBLIC_BLOCK_EXPLORER}/address/${row.original.address}`,
+                      `https://${getBlockExplorerDomain(row.original.chainId)}/address/${
+                        row.original.address
+                      }`,
                       '_blank',
                     );
                   }}
@@ -241,7 +245,7 @@ const PuzzleTableMobileSubComponent: FC<{ data: Puzzle }> = ({ data }) => {
           variant="outline"
           intent="neutral"
           rightIcon={<ExternalLink />}
-          href={`https://${process.env.NEXT_PUBLIC_BLOCK_EXPLORER}/address/${data.address}`}
+          href={`https://${getBlockExplorerDomain(data.chainId)}/address/${data.address}`}
           newTab
         >
           Contract

--- a/app/leaderboard/(components)/puzzles/table/desktop.tsx
+++ b/app/leaderboard/(components)/puzzles/table/desktop.tsx
@@ -242,7 +242,7 @@ const LeaderboardPuzzlesTableDesktopSubComponent: FC<{ data: Solve[] }> = ({ dat
                     '_blank',
                   );
                 }}
-                aria-label={`View ${row.original.solver}'s solution of puzzle ${row.original.puzzleId}.`}
+                aria-label={`View ${row.original.solver}'s solution of puzzle ${row.original.puzzleId} on chain ${row.original.chainId}.`}
               >
                 <ExternalLink />
               </IconButton>

--- a/app/leaderboard/(components)/puzzles/table/desktop.tsx
+++ b/app/leaderboard/(components)/puzzles/table/desktop.tsx
@@ -7,7 +7,7 @@ import type { ColumnDef } from '@tanstack/react-table';
 import { Crown, ExternalLink } from 'lucide-react';
 
 import type { Solve, Solver } from '@/lib/types/protocol';
-import { getTimeLeftString } from '@/lib/utils';
+import { getBlockExplorerDomain, getTimeLeftString } from '@/lib/utils';
 
 import AddressLinkClient from '@/components/templates/address-link-client';
 import ENSAvatarClient from '@/components/templates/ens-avatar-client';
@@ -232,11 +232,13 @@ const LeaderboardPuzzlesTableDesktopSubComponent: FC<{ data: Solve[] }> = ({ dat
               <IconButton
                 variant="outline"
                 intent="neutral"
-                title={`https://${process.env.NEXT_PUBLIC_BLOCK_EXPLORER}/tx/${row.original.tx}`}
+                title={`https://${getBlockExplorerDomain(row.original.chainId)}/tx/${
+                  row.original.tx
+                }`}
                 onClick={(e) => {
                   e.stopPropagation();
                   window.open(
-                    `https://${process.env.NEXT_PUBLIC_BLOCK_EXPLORER}/tx/${row.original.tx}`,
+                    `https://${getBlockExplorerDomain(row.original.chainId)}/tx/${row.original.tx}`,
                     '_blank',
                   );
                 }}

--- a/app/leaderboard/(components)/puzzles/table/mobile.tsx
+++ b/app/leaderboard/(components)/puzzles/table/mobile.tsx
@@ -7,7 +7,7 @@ import type { ColumnDef } from '@tanstack/react-table';
 import { ChevronRight, Crown, ExternalLink } from 'lucide-react';
 
 import type { Solver } from '@/lib/types/protocol';
-import { getTimeLeftString } from '@/lib/utils';
+import { getBlockExplorerDomain, getTimeLeftString } from '@/lib/utils';
 
 import AddressLinkClient from '@/components/templates/address-link-client';
 import ENSAvatarClient from '@/components/templates/ens-avatar-client';
@@ -154,7 +154,7 @@ const LeaderboardPuzzlesTableMobileSubComponent: FC<{ data: Solver }> = ({ data 
                 variant="outline"
                 intent="neutral"
                 rightIcon={<ExternalLink />}
-                href={`https://${process.env.NEXT_PUBLIC_BLOCK_EXPLORER}/tx/${solve.tx}`}
+                href={`https://${getBlockExplorerDomain(solve.chainId)}/tx/${solve.tx}`}
                 newTab
               >
                 View solution

--- a/app/puzzle/[id]/(components)/header/index.tsx
+++ b/app/puzzle/[id]/(components)/header/index.tsx
@@ -4,7 +4,7 @@ import PuzzleHeaderPageNav from './page-nav';
 import { ExternalLink, FileCheck, Github } from 'lucide-react';
 
 import type { Puzzle } from '@/lib/types/protocol';
-import { fetchPuzzleById } from '@/lib/utils';
+import { fetchPuzzleById, getBlockExplorerDomain } from '@/lib/utils';
 
 import AddressLink from '@/components/templates/address-link';
 import Avatar from '@/components/templates/avatar';
@@ -58,6 +58,7 @@ const PuzzleHeader: FC<PuzzleHeaderProps> = async ({ puzzle }) => {
             <AddressLink
               className="max-w-[13rem] overflow-hidden text-ellipsis text-xl font-medium text-gray-50 md:text-2xl"
               address={puzzle.author.address}
+              chainId={puzzle.chainId}
             />
           </div>
         </div>
@@ -90,7 +91,7 @@ const PuzzleHeader: FC<PuzzleHeaderProps> = async ({ puzzle }) => {
           ) : null}
           <Tooltip content="Contract">
             <IconButton
-              href={`https://${process.env.NEXT_PUBLIC_BLOCK_EXPLORER}/address/${puzzle.address}`}
+              href={`https://${getBlockExplorerDomain(puzzle.chainId)}/address/${puzzle.address}`}
               variant="outline"
               intent="neutral"
               size="lg"

--- a/app/puzzle/[id]/(components)/info/first-solver.tsx
+++ b/app/puzzle/[id]/(components)/info/first-solver.tsx
@@ -3,7 +3,7 @@ import type { FC } from 'react';
 import { ExternalLink } from 'lucide-react';
 
 import type { Puzzle } from '@/lib/types/protocol';
-import { getShortenedAddress, getTimeLeftString } from '@/lib/utils';
+import { getBlockExplorerDomain, getShortenedAddress, getTimeLeftString } from '@/lib/utils';
 
 // -----------------------------------------------------------------------------
 // Props
@@ -23,7 +23,7 @@ const PuzzleInfoFirstSolver: FC<PuzzleInfoFirstSolverProps> = ({ puzzle }) => {
       {puzzle.firstSolver ? (
         <a
           className="relative flex w-full flex-col items-center justify-center rounded-lg bg-tw-green py-2.5"
-          href={`https://${process.env.NEXT_PUBLIC_BLOCK_EXPLORER}/tx/${puzzle.solveTx}`}
+          href={`https://${getBlockExplorerDomain(puzzle.chainId)}/tx/${puzzle.solveTx}`}
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/app/puzzle/[id]/(components)/info/solution-form/index.tsx
+++ b/app/puzzle/[id]/(components)/info/solution-form/index.tsx
@@ -163,6 +163,7 @@ const PuzzleInfoSolutionForm: FC<PuzzleInfoSolutionFormProps> = ({ puzzle }) => 
               <PuzzleInfoSolutionFormTipForm
                 phase={phase}
                 author={puzzle.author}
+                chainId={puzzle.chainId}
                 onChange={setTip}
                 onOpenChange={setIsTipFormOpen}
               />

--- a/app/puzzle/[id]/(components)/info/solution-form/tip-form.tsx
+++ b/app/puzzle/[id]/(components)/info/solution-form/tip-form.tsx
@@ -1,7 +1,7 @@
 import { type FC, useState } from 'react';
 
 import type { Author, Phase } from '@/lib/types/protocol';
-import { getShortenedAddress } from '@/lib/utils';
+import { getBlockExplorerDomain, getShortenedAddress } from '@/lib/utils';
 
 import { Button, Input } from '@/components/ui';
 
@@ -12,6 +12,7 @@ import { Button, Input } from '@/components/ui';
 type PuzzleInfoSolutionFormTipFormProps = {
   phase: Phase;
   author: Author;
+  chainId: number;
   onChange: (value: string) => void;
   onOpenChange: (open: boolean) => void;
 };
@@ -23,6 +24,7 @@ type PuzzleInfoSolutionFormTipFormProps = {
 const PuzzleInfoSolutionFormTipForm: FC<PuzzleInfoSolutionFormTipFormProps> = ({
   phase,
   author,
+  chainId,
   onChange,
   onOpenChange,
 }) => {
@@ -48,7 +50,7 @@ const PuzzleInfoSolutionFormTipForm: FC<PuzzleInfoSolutionFormTipFormProps> = ({
         ill be transferred to{' '}
         <a
           className="font-medium text-gray-100 no-underline hover:underline"
-          href={`https://${process.env.NEXT_PUBLIC_BLOCK_EXPLORER}/address/${author.address}`}
+          href={`https://${getBlockExplorerDomain(chainId)}/address/${author.address}`}
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/app/puzzle/[id]/(components)/info/time-left/index.tsx
+++ b/app/puzzle/[id]/(components)/info/time-left/index.tsx
@@ -6,7 +6,7 @@ import PuzzleInfoTimeLeftTimeline from './timeline';
 import { ArrowUpRight, Box } from 'lucide-react';
 
 import type { Puzzle } from '@/lib/types/protocol';
-import { getPuzzleTimeLeft, getShortenedAddress } from '@/lib/utils';
+import { getBlockExplorerDomain, getPuzzleTimeLeft, getShortenedAddress } from '@/lib/utils';
 
 // -----------------------------------------------------------------------------
 // Props
@@ -59,7 +59,7 @@ const PuzzleInfoTimeLeft: FC<PuzzleInfoTimeLeftProps> = ({ puzzle }) => {
                 <a
                   key={blockNumber}
                   className="flex h-4 items-center gap-0.5 text-xs text-gray-100 hover:underline"
-                  href={`https://${process.env.NEXT_PUBLIC_BLOCK_EXPLORER}/block/${blockNumber}`}
+                  href={`https://${getBlockExplorerDomain(puzzle.chainId)}/block/${blockNumber}`}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
@@ -91,13 +91,13 @@ const PuzzleInfoTimeLeft: FC<PuzzleInfoTimeLeftProps> = ({ puzzle }) => {
                 value: `Added by ${
                   puzzle.author.ensName ?? getShortenedAddress(puzzle.author.address)
                 }`,
-                href: `https://${process.env.NEXT_PUBLIC_BLOCK_EXPLORER}/tx/${puzzle.addedTx}`,
+                href: `https://${getBlockExplorerDomain(puzzle.chainId)}/tx/${puzzle.addedTx}`,
               },
               {
                 name: 'Phase 1',
                 value: 'First blood',
                 href: puzzle.solveTx
-                  ? `https://${process.env.NEXT_PUBLIC_BLOCK_EXPLORER}/tx/${puzzle.solveTx}`
+                  ? `https://${getBlockExplorerDomain(puzzle.chainId)}/tx/${puzzle.solveTx}`
                   : undefined,
               },
               {

--- a/app/puzzle/[id]/(components)/problem-display.tsx
+++ b/app/puzzle/[id]/(components)/problem-display.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { FC, useState } from 'react';
+import { type FC, useState } from 'react';
 
 import type { Puzzle } from '@/lib/types/protocol';
+import { getBlockExplorerDomain } from '@/lib/utils';
 
 import { CodeBlock } from '@/components/ui';
 
@@ -32,7 +33,9 @@ const PuzzleProblemDisplay: FC<PuzzleProblemDisplayProps> = ({ puzzle, languages
       <div className="flex items-center gap-1 text-sm">
         <a
           className="font-medium text-gray-100 hover:underline"
-          href={`https://${process.env.NEXT_PUBLIC_BLOCK_EXPLORER}/address/${process.env.NEXT_PUBLIC_CURTA_ADDRESS}`}
+          href={`https://${getBlockExplorerDomain(puzzle.chainId)}/address/${
+            process.env.NEXT_PUBLIC_CURTA_ADDRESS
+          }`}
           target="_blank"
           rel="noreferrer"
         >

--- a/app/puzzle/[id]/(components)/solves-table.tsx
+++ b/app/puzzle/[id]/(components)/solves-table.tsx
@@ -7,7 +7,7 @@ import type { ColumnDef } from '@tanstack/react-table';
 import { ExternalLink } from 'lucide-react';
 
 import type { Solve } from '@/lib/types/protocol';
-import { getTimeLeftString } from '@/lib/utils';
+import { getBlockExplorerDomain, getTimeLeftString } from '@/lib/utils';
 
 import AddressLinkClient from '@/components/templates/address-link-client';
 import ENSAvatarClient from '@/components/templates/ens-avatar-client';
@@ -118,11 +118,13 @@ const PuzzleSolvesTableDesktop: FC<PuzzleSolvesTableInternalProps> = ({
               <IconButton
                 variant="outline"
                 intent="neutral"
-                title={`https://${process.env.NEXT_PUBLIC_BLOCK_EXPLORER}/tx/${row.original.tx}`}
+                title={`https://${getBlockExplorerDomain(row.original.chainId)}/tx/${
+                  row.original.tx
+                }`}
                 onClick={(e) => {
                   e.stopPropagation();
                   window.open(
-                    `https://${process.env.NEXT_PUBLIC_BLOCK_EXPLORER}/tx/${row.original.tx}`,
+                    `https://${getBlockExplorerDomain(row.original.chainId)}/tx/${row.original.tx}`,
                     '_blank',
                   );
                 }}

--- a/app/puzzle/[id]/(components)/solves-table.tsx
+++ b/app/puzzle/[id]/(components)/solves-table.tsx
@@ -128,7 +128,7 @@ const PuzzleSolvesTableDesktop: FC<PuzzleSolvesTableInternalProps> = ({
                     '_blank',
                   );
                 }}
-                aria-label={`View ${row.original.solver}'s solution of puzzle ${row.original.puzzleId}.`}
+                aria-label={`View ${row.original.solver}'s solution of puzzle ${row.original.puzzleId} on chain ${row.original.chainId}.`}
               >
                 <ExternalLink />
               </IconButton>

--- a/app/puzzle/[id]/loading.tsx
+++ b/app/puzzle/[id]/loading.tsx
@@ -9,6 +9,8 @@ import {
   ToggleRight,
 } from 'lucide-react';
 
+import { getBlockExplorerDomain } from '@/lib/utils';
+
 import { Button, CodeBlock, IconButton, Input } from '@/components/ui';
 
 export default function LoadingPage() {
@@ -71,7 +73,10 @@ export default function LoadingPage() {
             <div className="flex items-center gap-1 text-sm">
               <a
                 className="font-medium text-gray-100 hover:underline"
-                href={`https://${process.env.NEXT_PUBLIC_BLOCK_EXPLORER}/address/${process.env.NEXT_PUBLIC_CURTA_ADDRESS}`}
+                // Default to Curta Puzzles on Ethereum
+                href={`https://${getBlockExplorerDomain(1)}/address/${
+                  process.env.NEXT_PUBLIC_CURTA_ADDRESS
+                }`}
                 target="_blank"
                 rel="noreferrer"
               >

--- a/components/common/nav-bar.tsx
+++ b/components/common/nav-bar.tsx
@@ -12,7 +12,7 @@ import { useAccount, useDisconnect, useEnsName } from 'wagmi';
 
 import { NAVBAR_PAGES, SOCIAL_LINKS } from '@/lib/constants/site';
 import { useMediaQuery } from '@/lib/hooks/useMediaQuery';
-import { getShortenedAddress } from '@/lib/utils';
+import { getBlockExplorerDomain, getShortenedAddress } from '@/lib/utils';
 
 import { Button, IconButton, Modal } from '@/components/ui';
 
@@ -139,7 +139,8 @@ const NavBarMobile: FC<NavBarInternalProps> = ({ yScroll }) => {
                   <a
                     id="connected-address-link"
                     className="line-clamp-1 text-ellipsis font-medium text-gray-100 transition-colors hover:underline"
-                    href={`https://${process.env.NEXT_PUBLIC_BLOCK_EXPLORER}/address/${address}`}
+                    // Always link to Ethereum's block explorer
+                    href={`https://${getBlockExplorerDomain(1)}/address/${address}`}
                     target="_blank"
                     rel="noopener noreferrer"
                   >
@@ -153,7 +154,8 @@ const NavBarMobile: FC<NavBarInternalProps> = ({ yScroll }) => {
                 <div className="flex gap-2">
                   {[
                     {
-                      href: `https://${process.env.NEXT_PUBLIC_BLOCK_EXPLORER}/address/${address}`,
+                      // Always link to Ethereum's block explorer
+                      href: `https://${getBlockExplorerDomain(1)}/address/${address}`,
                       newTab: true,
                       children: <ExternalLink />,
                     },

--- a/components/templates/address-link-client.tsx
+++ b/components/templates/address-link-client.tsx
@@ -7,7 +7,7 @@ import { twMerge } from 'tailwind-merge';
 import type { Address } from 'viem';
 import { useEnsName } from 'wagmi';
 
-import { getShortenedAddress } from '@/lib/utils';
+import { getBlockExplorerDomain, getShortenedAddress } from '@/lib/utils';
 
 // ---------------------------------------–-------------------------------------
 // Props
@@ -16,6 +16,7 @@ import { getShortenedAddress } from '@/lib/utils';
 type AddressLinkClientProps = {
   className?: string;
   address: Address;
+  chainId?: number;
   prefetchedEnsName?: string;
 };
 
@@ -26,6 +27,7 @@ type AddressLinkClientProps = {
 const AddressLinkClient: FC<AddressLinkClientProps> = ({
   className,
   address,
+  chainId = 1,
   prefetchedEnsName,
 }) => {
   const [mounted, setMounted] = useState<boolean>(false);
@@ -45,7 +47,7 @@ const AddressLinkClient: FC<AddressLinkClientProps> = ({
           className,
         ),
       )}
-      href={`https://${process.env.NEXT_PUBLIC_BLOCK_EXPLORER}/address/${address}`}
+      href={`https://${getBlockExplorerDomain(chainId)}/address/${address}`}
       target="_blank"
       rel="noopener noreferrer"
       onClick={(e) => e.stopPropagation()}

--- a/components/templates/address-link.tsx
+++ b/components/templates/address-link.tsx
@@ -5,7 +5,7 @@ import { twMerge } from 'tailwind-merge';
 import type { Address } from 'viem';
 
 import { publicClient } from '@/lib/client';
-import { getShortenedAddress } from '@/lib/utils';
+import { getBlockExplorerDomain, getShortenedAddress } from '@/lib/utils';
 
 // ---------------------------------------–-------------------------------------
 // Props
@@ -14,6 +14,7 @@ import { getShortenedAddress } from '@/lib/utils';
 export type AddressLinkProps = {
   className?: string;
   address?: Address;
+  chainId?: number;
   href?: string;
 };
 
@@ -21,7 +22,7 @@ export type AddressLinkProps = {
 // Component
 // ---------------------------------------–-------------------------------------
 
-const AddressLink: FC<AddressLinkProps> = async ({ className, address, href }) => {
+const AddressLink: FC<AddressLinkProps> = async ({ className, address, chainId = 1, href }) => {
   const ensName = address
     ? await cache(async () => await publicClient.getEnsName({ address }))()
     : undefined;
@@ -35,7 +36,7 @@ const AddressLink: FC<AddressLinkProps> = async ({ className, address, href }) =
           className,
         ),
       )}
-      href={href ?? `https://${process.env.NEXT_PUBLIC_BLOCK_EXPLORER}/address/${address}`}
+      href={href ?? `https://${getBlockExplorerDomain(chainId)}/address/${address}`}
       target="_blank"
       rel="noopener noreferrer"
     >

--- a/environment.d.ts
+++ b/environment.d.ts
@@ -2,7 +2,6 @@ declare global {
   namespace NodeJS {
     interface ProcessEnv {
       // Site config
-      NEXT_PUBLIC_BLOCK_EXPLORER: string;
       NEXT_PUBLIC_BASE_URL: string;
       CURTA_SITE_API_KEY: string;
       // Chain config

--- a/lib/types/protocol.ts
+++ b/lib/types/protocol.ts
@@ -50,6 +50,7 @@ export type Puzzle = {
 };
 
 export type Solve = {
+  chainId: number;
   solver: `0x${string}`;
   solverEnsName?: string;
   solverEnsAvatar?: string;

--- a/lib/utils/fetchLeaderboardPuzzles.ts
+++ b/lib/utils/fetchLeaderboardPuzzles.ts
@@ -86,6 +86,7 @@ const fetchLeaderboardPuzzles = async (
     }
     solversObject[solver].count.total++;
     solversObject[solver].solves.push({
+      chainId: 1, // TODO: use fetched data from new database.
       solver: item.solver,
       solveTimestamp: item.solveTimestamp,
       puzzleId: item.puzzleId,

--- a/lib/utils/fetchPuzzleSolvesById.ts
+++ b/lib/utils/fetchPuzzleSolvesById.ts
@@ -27,6 +27,7 @@ const fetchPuzzleSolvesById = async (id: number): Promise<PuzzleSolvesResponse> 
     const solve = data[i];
 
     solves.push({
+      chainId: 1, // TODO: use fetched data from new database.
       solver: solve.solver,
       solveTimestamp: solve.solveTimestamp,
       puzzleId: solve.puzzleId,

--- a/lib/utils/getBlockExplorerDomain.ts
+++ b/lib/utils/getBlockExplorerDomain.ts
@@ -1,0 +1,15 @@
+/**
+ * Return a block explorer domain for a given chain.
+ * @dev If the chain is not supported, the function returns a domain for
+ * Ethereum (`etherscan.io`).
+ * @param chainId The ID of the chain.
+ * @returns The block explorer domain (without the `https://` prefix).
+ */
+const getBlockExplorerDomain = (chainId: number): string => {
+  if (chainId === 8453) return 'basescan.org';
+
+  // Return Ethereum's block explorer by default.
+  return 'etherscan.io';
+};
+
+export default getBlockExplorerDomain;

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -8,6 +8,7 @@ import fetchPuzzleSolvesById from './fetchPuzzleSolvesById';
 import fetchSolvesCount from './fetchSolvesCount';
 import formatValueToPrecision from './formatValueToPrecision';
 import getBaseMetadata from './getBaseMetadata';
+import getBlockExplorerDomain from './getBlockExplorerDomain';
 import getPuzzleTimeLeft from './getPuzzleTimeLeft';
 import getShortenedAddress from './getShortenedAddress';
 import getTimeLeftString from './getTimeLeftString';
@@ -23,6 +24,7 @@ export {
   fetchSolvesCount,
   formatValueToPrecision,
   getBaseMetadata,
+  getBlockExplorerDomain,
   getPuzzleTimeLeft,
   getShortenedAddress,
   getTimeLeftString,


### PR DESCRIPTION
## Description
Adds a function `getBlockExplorerDomain(chainId: number)` @ `@/lib/utils` to fetch a block explorer for a given chain. It defaults to a block explorer for Ethereum (`etherscan.io`) if the site/function doesn't support the chain.

This PR also replaces all instances of `process.env.NEXT_PUBLIC_BLOCK_EXPLORER` with `getBlockExplorerDomain` to continue the migration towards a more seamless multichain UX/DX site.