### PR TITLE
Add event leaderboard

### DIFF
--- a/app/docs/leaderboard/page.mdx
+++ b/app/docs/leaderboard/page.mdx
@@ -75,3 +75,7 @@ The leaderboard resets with a new **season** every 5 puzzles to allow newcomers 
 >
   <source src="/assets/leaderboard-seasons-3x.mp4" type="video/mp4" />
 </video>
+
+<Callout intent="primary">
+  The all-time leaderboard excludes puzzles that are part of an event from its ranking.
+</Callout>

--- a/app/leaderboard/(components)/puzzles/content.tsx
+++ b/app/leaderboard/(components)/puzzles/content.tsx
@@ -188,7 +188,9 @@ const LeaderboardPuzzlesContent: FC<LeaderboardPuzzlesContentProps> = ({
                               />
                             ) : null}
                             <span className="w-fit whitespace-nowrap">
-                              Puzzles {minPuzzleIndex}-{season > 0 ? season * 5 : puzzles}
+                              {season > 0
+                                ? '5 puzzles'
+                                : `${maxPuzzleIndex - minPuzzleIndex + 1} puzzles`}
                             </span>
                           </Fragment>
                         ),

--- a/app/leaderboard/(components)/puzzles/content.tsx
+++ b/app/leaderboard/(components)/puzzles/content.tsx
@@ -166,9 +166,7 @@ const LeaderboardPuzzlesContent: FC<LeaderboardPuzzlesContentProps> = ({
   // `loading` is true if `data` is inconsistent with the selected season. The
   // `season !== maxSeason` condition is present because we already have the
   // latest season's data via `defaultData`.
-  const loading = false; // TODO
-  /* (minPuzzleIndex !== data?.minPuzzleIndex || maxPuzzleIndex !== data?.maxPuzzleIndex) &&
-    season !== maxSeason; */
+  const loading = filter !== data?.filter && filter !== `season_${maxSeason}`;
 
   return (
     <Fragment>

--- a/app/leaderboard/(components)/puzzles/content.tsx
+++ b/app/leaderboard/(components)/puzzles/content.tsx
@@ -17,6 +17,7 @@ import LeaderboardPuzzlesTableSkeleton from './table-skeleton';
 import clsx from 'clsx';
 import { ChevronRightCircle, ExternalLink } from 'lucide-react';
 
+import type { Event } from '@/lib/types/protocol';
 import type { LeaderboardPuzzlesResponse } from '@/lib/utils/fetchLeaderboardPuzzles';
 
 import PhaseTagPing from '@/components/templates/phase-tag/ping';
@@ -29,6 +30,7 @@ import { Button, Select } from '@/components/ui';
 type LeaderboardPuzzlesContentProps = {
   maxSeason: number;
   puzzles: number;
+  events: Event[];
   defaultData: LeaderboardPuzzlesResponse['data'];
 };
 
@@ -44,8 +46,10 @@ type LeaderboardPuzzlesFilterAndValue =
 const LeaderboardPuzzlesContent: FC<LeaderboardPuzzlesContentProps> = ({
   maxSeason,
   puzzles,
+  events,
   defaultData,
 }) => {
+  console.log(events);
   const searchParams = useSearchParams();
   // ---------------------------------------------------------------------------
   // URL search param parsing

--- a/app/leaderboard/(components)/puzzles/content.tsx
+++ b/app/leaderboard/(components)/puzzles/content.tsx
@@ -59,7 +59,8 @@ const LeaderboardPuzzlesContent: FC<LeaderboardPuzzlesContentProps> = ({
   //                 to the latest season.
   //     * `event`: Include all puzzles from the parsed event number. In the
   //                form of `event_${eventSlug}`. If the parsed event slug is
-  //                not a valid event slug, set the data to the latest season.
+  //                not a valid event slug, set the default event to the latest
+  //                event.
   const filterSearchParam = searchParams.get('filter')?.toLowerCase() ?? `season_${maxSeason}`; // Default to max season.
   const filterTypeAndValue = getFilterTypeAndValue(filterSearchParam, maxSeason);
   const defaultSeason = filterTypeAndValue.type === 'season' ? filterTypeAndValue.value : maxSeason; // Default to max season.

--- a/app/leaderboard/(components)/puzzles/content.tsx
+++ b/app/leaderboard/(components)/puzzles/content.tsx
@@ -71,7 +71,7 @@ const LeaderboardPuzzlesContent: FC<LeaderboardPuzzlesContentProps> = ({
     filterTypeAndValue.type === 'event'
       ? filterTypeAndValue.value
       : events.length > 0
-      ? events[events.length - 1].slug // Default to last event by default.
+      ? events[events.length - 1].slug // Default to latest event slug by default.
       : '';
 
   // ---------------------------------------------------------------------------
@@ -80,7 +80,6 @@ const LeaderboardPuzzlesContent: FC<LeaderboardPuzzlesContentProps> = ({
 
   const [filter, setFilter] = useState<string>(getFilter(filterTypeAndValue));
   const [season, setSeason] = useState<number>(defaultSeason);
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [eventSlug, setEventSlug] = useState<string>(defaultEventSlug);
   const [data, setData] = useState<LeaderboardPuzzlesResponse['data']>();
   const [scrollIsAtLeft, setScrollIsAtLeft] = useState<boolean>(true);
@@ -88,6 +87,9 @@ const LeaderboardPuzzlesContent: FC<LeaderboardPuzzlesContentProps> = ({
   const router = useRouter();
   const pathname = usePathname();
   const isSeasonOver = season * 5 <= puzzles;
+  const isEventOver =
+    (events.find((event) => event.slug === eventSlug)?.endDate ?? Number.MAX_SAFE_INTEGER) <
+    Date.now() / 1000;
 
   const fetchAndSetData = useCallback(
     async (filter: LeaderboardPuzzlesFilterAndValue) => {
@@ -206,16 +208,28 @@ const LeaderboardPuzzlesContent: FC<LeaderboardPuzzlesContentProps> = ({
                       {
                         children: (
                           <Fragment>
-                            {season > 0 ? (
-                              <PhaseTagPing
-                                phase={isSeasonOver ? 3 : 0}
-                                isPinging={!isSeasonOver}
-                                title={
-                                  isSeasonOver
-                                    ? 'All puzzles for this season have been added.'
-                                    : 'There are still puzzles to be added for this season.'
-                                }
-                              />
+                            {filter !== 'all' ? (
+                              filter.startsWith('season_') ? (
+                                <PhaseTagPing
+                                  phase={isSeasonOver ? 3 : 0}
+                                  isPinging={!isSeasonOver}
+                                  title={
+                                    isSeasonOver
+                                      ? 'All puzzles for this season have been added.'
+                                      : 'There are still puzzles to be added for this season.'
+                                  }
+                                />
+                              ) : (
+                                <PhaseTagPing
+                                  phase={isEventOver ? 3 : 0}
+                                  isPinging={!isEventOver}
+                                  title={
+                                    isEventOver
+                                      ? 'The event is over.'
+                                      : 'There event is still ongoing.'
+                                  }
+                                />
+                              )
                             ) : null}
                             <span className="w-fit whitespace-nowrap">
                               {`${data?.puzzles ?? 5} puzzles`}

--- a/app/leaderboard/(components)/puzzles/content.tsx
+++ b/app/leaderboard/(components)/puzzles/content.tsx
@@ -163,9 +163,9 @@ const LeaderboardPuzzlesContent: FC<LeaderboardPuzzlesContentProps> = ({
     setScrollIsAtRight(scrollWidth - scrollLeft === clientWidth);
   };
 
-  // `loading` is true if `data` is inconsistent with the selected season. The
-  // `season !== maxSeason` condition is present because we already have the
-  // latest season's data via `defaultData`.
+  // `loading` is true if `data` is inconsistent with the selected filter. The
+  // `filter !== \`season_${maxSeason}\`` condition is present because we
+  // already have the latest season's data via `defaultData`.
   const loading = filter !== data?.filter && filter !== `season_${maxSeason}`;
 
   return (

--- a/app/leaderboard/(components)/puzzles/content.tsx
+++ b/app/leaderboard/(components)/puzzles/content.tsx
@@ -99,8 +99,10 @@ const LeaderboardPuzzlesContent: FC<LeaderboardPuzzlesContentProps> = ({
   // Fetch the data for the default filters on component mount if it's not the
   // default filter.
   useEffect(() => {
-    fetchAndSetData({ type: 'season', value: season });
-  }, [fetchAndSetData, season]);
+    if (filter !== `season_${maxSeason}`) {
+      fetchAndSetData(getFilterTypeAndValue(filter, maxSeason, events));
+    }
+  }, [events, fetchAndSetData, filter, maxSeason]);
 
   // A helper function to update the URL search params when a user filters to a
   // new season in the table via the UI to keep URL<>component states synced.

--- a/app/leaderboard/(components)/puzzles/content.tsx
+++ b/app/leaderboard/(components)/puzzles/content.tsx
@@ -218,7 +218,7 @@ const LeaderboardPuzzlesContent: FC<LeaderboardPuzzlesContentProps> = ({
                               />
                             ) : null}
                             <span className="w-fit whitespace-nowrap">
-                              {season > 0 ? '5 puzzles' : `${10 - 9 + 1} puzzles`} {/* TODO */}
+                              {`${data?.puzzles ?? 5} puzzles`}
                             </span>
                           </Fragment>
                         ),
@@ -233,7 +233,7 @@ const LeaderboardPuzzlesContent: FC<LeaderboardPuzzlesContentProps> = ({
                         {item.children}
                       </div>
                     ))
-                  : [108, 76, 72].map((width, i) => (
+                  : [78, 76, 72].map((width, i) => (
                       <div
                         key={i}
                         className="h-6 animate-pulse rounded-full bg-gray-350"

--- a/app/leaderboard/(components)/puzzles/content.tsx
+++ b/app/leaderboard/(components)/puzzles/content.tsx
@@ -226,7 +226,7 @@ const LeaderboardPuzzlesContent: FC<LeaderboardPuzzlesContentProps> = ({
                                   title={
                                     isEventOver
                                       ? 'The event is over.'
-                                      : 'There event is still ongoing.'
+                                      : 'The event is still ongoing.'
                                   }
                                 />
                               )

--- a/app/leaderboard/(components)/puzzles/content.tsx
+++ b/app/leaderboard/(components)/puzzles/content.tsx
@@ -91,9 +91,9 @@ const LeaderboardPuzzlesContent: FC<LeaderboardPuzzlesContentProps> = ({
 
   const fetchAndSetData = useCallback(
     async (filter: LeaderboardPuzzlesFilterAndValue) => {
-      setData((await fetchLeaderboardData(filter, puzzles, maxSeason)).data);
+      setData((await fetchLeaderboardData(filter, puzzles)).data);
     },
-    [maxSeason, puzzles],
+    [puzzles],
   );
 
   // Fetch the data for the default filters on component mount if it's not the

--- a/app/leaderboard/(components)/puzzles/index.tsx
+++ b/app/leaderboard/(components)/puzzles/index.tsx
@@ -24,7 +24,11 @@ const LeaderboardPuzzles: FC<LeaderboardPuzzlesProps> = async ({ puzzles }) => {
   const maxPuzzleIndex = Math.min(puzzles, maxSeason * 5);
   // Fetch the data of the latest season (i.e. data that is displayed by
   // default).
-  const { data: defaultData } = await fetchLeaderboardPuzzles({ minPuzzleIndex, maxPuzzleIndex });
+  const { data: defaultData } = await fetchLeaderboardPuzzles({
+    minPuzzleIndex,
+    maxPuzzleIndex,
+    filter: `season_${maxSeason}`,
+  });
   // Fetch all events.
   const { data: events } = await fetchEvents();
 

--- a/app/leaderboard/(components)/puzzles/index.tsx
+++ b/app/leaderboard/(components)/puzzles/index.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react';
 
 import LeaderboardPuzzlesContent from './content';
 
-import { fetchLeaderboardPuzzles } from '@/lib/utils';
+import { fetchEvents, fetchLeaderboardPuzzles } from '@/lib/utils';
 
 import { Card } from '@/components/ui';
 
@@ -24,13 +24,20 @@ const LeaderboardPuzzles: FC<LeaderboardPuzzlesProps> = async ({ puzzles }) => {
   const maxPuzzleIndex = Math.min(puzzles, maxSeason * 5);
   // Fetch the data of the latest season (i.e. data that is displayed by
   // default).
-  const { data } = await fetchLeaderboardPuzzles({ minPuzzleIndex, maxPuzzleIndex });
+  const { data: defaultData } = await fetchLeaderboardPuzzles({ minPuzzleIndex, maxPuzzleIndex });
+  // Fetch all events.
+  const { data: events } = await fetchEvents();
 
   return (
     <Card>
       <Card.Header>Puzzles</Card.Header>
       <Card.Body noPadding>
-        <LeaderboardPuzzlesContent maxSeason={maxSeason} puzzles={puzzles} defaultData={data} />
+        <LeaderboardPuzzlesContent
+          maxSeason={maxSeason}
+          puzzles={puzzles}
+          events={events}
+          defaultData={defaultData}
+        />
       </Card.Body>
     </Card>
   );

--- a/app/leaderboard/(components)/puzzles/server-action.ts
+++ b/app/leaderboard/(components)/puzzles/server-action.ts
@@ -10,12 +10,26 @@ export default async function action(
   maxSeason: number,
 ) {
   if (filter.type === 'all') {
-    return await fetchLeaderboardPuzzles();
+    return await fetchLeaderboardPuzzles({
+      minPuzzleIndex: 1,
+      maxPuzzleIndex: Number.MAX_SAFE_INTEGER,
+      filter: 'all',
+      excludeEvents: true,
+    });
   } else if (filter.type === 'season' && filter.value !== maxSeason) {
     const minPuzzleIndex = (filter.value - 1) * 5 + 1;
     const maxPuzzleIndex = Math.min(puzzles, filter.value * 5);
-    return await fetchLeaderboardPuzzles({ minPuzzleIndex, maxPuzzleIndex });
+    return await fetchLeaderboardPuzzles({
+      minPuzzleIndex,
+      maxPuzzleIndex,
+      filter: `season_${filter.value}`,
+    });
   }
 
-  return await fetchLeaderboardPuzzles();
+  // TODO
+  return await fetchLeaderboardPuzzles({
+    minPuzzleIndex: 1,
+    maxPuzzleIndex: puzzles,
+    filter: 'all',
+  });
 }

--- a/app/leaderboard/(components)/puzzles/server-action.ts
+++ b/app/leaderboard/(components)/puzzles/server-action.ts
@@ -30,6 +30,6 @@ export default async function action(
   return await fetchLeaderboardPuzzles({
     minPuzzleIndex: 1,
     maxPuzzleIndex: puzzles,
-    filter: 'all',
+    filter: `event_${filter.value}`,
   });
 }

--- a/app/leaderboard/(components)/puzzles/server-action.ts
+++ b/app/leaderboard/(components)/puzzles/server-action.ts
@@ -4,11 +4,7 @@ import type { LeaderboardPuzzlesFilterAndValue } from './content';
 
 import { fetchLeaderboardPuzzles } from '@/lib/utils';
 
-export default async function action(
-  filter: LeaderboardPuzzlesFilterAndValue,
-  puzzles: number,
-  maxSeason: number,
-) {
+export default async function action(filter: LeaderboardPuzzlesFilterAndValue, puzzles: number) {
   if (filter.type === 'all') {
     return await fetchLeaderboardPuzzles({
       minPuzzleIndex: 1,
@@ -16,9 +12,10 @@ export default async function action(
       filter: 'all',
       excludeEvents: true,
     });
-  } else if (filter.type === 'season' && filter.value !== maxSeason) {
+  } else if (filter.type === 'season') {
     const minPuzzleIndex = (filter.value - 1) * 5 + 1;
     const maxPuzzleIndex = Math.min(puzzles, filter.value * 5);
+
     return await fetchLeaderboardPuzzles({
       minPuzzleIndex,
       maxPuzzleIndex,
@@ -26,10 +23,10 @@ export default async function action(
     });
   }
 
-  // TODO
   return await fetchLeaderboardPuzzles({
     minPuzzleIndex: 1,
-    maxPuzzleIndex: puzzles,
+    maxPuzzleIndex: Number.MAX_SAFE_INTEGER,
     filter: `event_${filter.value}`,
+    eventSlug: filter.value,
   });
 }

--- a/app/leaderboard/(components)/puzzles/server-action.ts
+++ b/app/leaderboard/(components)/puzzles/server-action.ts
@@ -1,17 +1,21 @@
 'use server';
 
+import type { LeaderboardPuzzlesFilterAndValue } from './content';
+
 import { fetchLeaderboardPuzzles } from '@/lib/utils';
 
 export default async function action(
-  {
-    minPuzzleIndex = 0,
-    maxPuzzleIndex = Number.MAX_SAFE_INTEGER,
-  }: {
-    minPuzzleIndex?: number;
-    maxPuzzleIndex?: number;
-  } = { minPuzzleIndex: 0, maxPuzzleIndex: Number.MAX_SAFE_INTEGER },
+  filter: LeaderboardPuzzlesFilterAndValue,
+  puzzles: number,
+  maxSeason: number,
 ) {
-  const puzzles = await fetchLeaderboardPuzzles({ minPuzzleIndex, maxPuzzleIndex });
+  if (filter.type === 'all') {
+    return await fetchLeaderboardPuzzles();
+  } else if (filter.type === 'season' && filter.value !== maxSeason) {
+    const minPuzzleIndex = (filter.value - 1) * 5 + 1;
+    const maxPuzzleIndex = Math.min(puzzles, filter.value * 5);
+    return await fetchLeaderboardPuzzles({ minPuzzleIndex, maxPuzzleIndex });
+  }
 
-  return puzzles;
+  return await fetchLeaderboardPuzzles();
 }

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -78,7 +78,6 @@ export type DbUser = {
  * @param github A link to the puzzle's GitHub repository.
  * @param disabled Whether or not the puzzle should be displayed on the
  * frontend.
- * @param isEvent Whether or not the puzzle is part of an event.
  * @param eventId The ID of the event the puzzle is part of.
  * @param sponsorshipId The ID of the sponsorship relevant to the puzzle.
  * @param bytecode The puzzle's contract bytecode.
@@ -107,7 +106,6 @@ export type DbPuzzle = {
   solution?: string;
   github?: string;
   disabled?: boolean;
-  isEvent?: boolean;
   eventId?: string;
   sponsorshipId?: string;
   // Puzzle source code

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -5,6 +5,33 @@ import type { Address, Hash } from 'viem';
 // -----------------------------------------------------------------------------
 
 /**
+ * Type for an object representing a Curta event stored in the database's
+ * `events` table.
+ * @param id The event's ID (auto-generated `uuid`).
+ * @param slug The event's slug (unique).
+ * @param name The event's name.
+ * @param description A short description about the event.
+ * @param link External link relevant to the event.
+ * @param image An image relevant to the event.
+ * @param startDate The timestamp the event starts at.
+ * @param endDate The timestamp the event ends at.
+ * @param location The location of the event.
+ */
+export type DbEvent = {
+  // Primary key
+  id: string; // Auto-generated
+  // Event information
+  slug: string;
+  name: string;
+  description?: string;
+  link?: string;
+  image?: string;
+  startDate: number;
+  endDate: number;
+  location?: string;
+};
+
+/**
  * Type for an object representing a Curta user stored in the database's `users`
  * table.
  * @param address The user's Ethereum address (hex, should be all lowercase).
@@ -132,19 +159,4 @@ export type DbPuzzleSolve = {
 
 export type Error = {
   message: string;
-};
-
-export type SupabaseSolve = {
-  // Primary key
-  id: string; // string because it's a hex-string
-  puzzleId: number;
-  solver: `0x${string}`;
-  // Solve information
-  phase: number;
-  solution: `0x${string}`;
-  // Solve transaction information
-  solveTimestamp: number;
-  solveTx: `0x${string}`;
-  tokenImage: string;
-  created_at: number;
 };

--- a/lib/types/protocol.ts
+++ b/lib/types/protocol.ts
@@ -118,7 +118,7 @@ export type Phase = 0 | 1 | 2 | 3;
  * @param github A link to the puzzle's GitHub repository.
  * @param disabled Whether or not the puzzle should be displayed on the
  * frontend.
- * @param isEvent Whether or not the puzzle is part of an event.
+ * @param event The event the puzzle is for (if any).
  * @param bytecode The puzzle's contract bytecode.
  * @param solidity The puzzle's Solidity source code.
  * @param huff The puzzle's Huff source code.
@@ -148,7 +148,7 @@ export type Puzzle = {
   solution?: string;
   github?: string;
   disabled?: boolean;
-  isEvent?: boolean;
+  event?: Event;
   // Puzzle source code
   bytecode: string;
   solidity?: string;

--- a/lib/types/protocol.ts
+++ b/lib/types/protocol.ts
@@ -5,6 +5,30 @@ import type { Address, Hash } from 'viem';
 // -----------------------------------------------------------------------------
 
 /**
+ * Type for an object representing a Curta event.
+ * @param slug The event's slug (unique).
+ * @param name The event's name.
+ * @param description A short description about the event.
+ * @param link External link relevant to the event.
+ * @param image An image relevant to the event.
+ * @param startDate The timestamp the event starts at.
+ * @param endDate The timestamp the event ends at.
+ * @param location The location of the event.
+ */
+export type Event = {
+  // Identifier
+  slug: string;
+  // Event information
+  name: string;
+  description?: string;
+  link?: string;
+  image?: string;
+  startDate: number;
+  endDate: number;
+  location?: string;
+};
+
+/**
  * Type for an object representing a Curta user.
  * @param address The user's Ethereum address (hex, should be all lowercase).
  * @param username The user's unique username. If the user never set a username,
@@ -20,7 +44,7 @@ import type { Address, Hash } from 'viem';
  * @param ensName User's prefetched ENS name.
  */
 export type User = {
-  // Primary key
+  // Identifier
   address: Address;
   // User information
   username: string;

--- a/lib/utils/fetchEvents.ts
+++ b/lib/utils/fetchEvents.ts
@@ -1,0 +1,34 @@
+import type { PostgrestError } from '@supabase/supabase-js';
+
+import supabase from '@/lib/services/supabase';
+import type { DbEvent } from '@/lib/types/api';
+import type { Event } from '@/lib/types/protocol';
+
+type EventsResponse = {
+  data: Event[];
+  status: number;
+  error: PostgrestError | null;
+};
+
+const fetchEvents = async (): Promise<EventsResponse> => {
+  const { data, status, error } = await supabase.from('events').select('*').returns<DbEvent[]>();
+
+  if ((error && status !== 406) || !data || (data && data.length === 0)) {
+    return { data: [], status, error };
+  }
+
+  const events: Event[] = data.map((item) => ({
+    slug: item.slug,
+    name: item.name,
+    description: item.description,
+    link: item.link,
+    image: item.image,
+    startDate: item.startDate,
+    endDate: item.endDate,
+    location: item.location,
+  }));
+
+  return { data: events, status, error };
+};
+
+export default fetchEvents;

--- a/lib/utils/fetchEvents.ts
+++ b/lib/utils/fetchEvents.ts
@@ -11,12 +11,17 @@ type EventsResponse = {
 };
 
 /**
- * Fetches and returns all events from the database.
+ * Fetches and returns all events, sorted from earliest start date to latest
+ * start date from the database.
  * @returns An object containing data for the events, the status code, and the
  * error in the shape `{ data: Event[], status: number, error: PostgrestError | null }`.
  */
 const fetchEvents = async (): Promise<EventsResponse> => {
-  const { data, status, error } = await supabase.from('events').select('*').returns<DbEvent[]>();
+  const { data, status, error } = await supabase
+    .from('events')
+    .select('*')
+    .order('startDate', { ascending: true })
+    .returns<DbEvent[]>();
 
   if ((error && status !== 406) || !data || (data && data.length === 0)) {
     return { data: [], status, error };

--- a/lib/utils/fetchEvents.ts
+++ b/lib/utils/fetchEvents.ts
@@ -10,6 +10,11 @@ type EventsResponse = {
   error: PostgrestError | null;
 };
 
+/**
+ * Fetches and returns all events from the database.
+ * @returns An object containing data for the events, the status code, and the
+ * error in the shape `{ data: Event[], status: number, error: PostgrestError | null }`.
+ */
 const fetchEvents = async (): Promise<EventsResponse> => {
   const { data, status, error } = await supabase.from('events').select('*').returns<DbEvent[]>();
 

--- a/lib/utils/fetchLeaderboardPuzzles.ts
+++ b/lib/utils/fetchLeaderboardPuzzles.ts
@@ -54,8 +54,8 @@ const fetchLeaderboardPuzzles = async ({
   const { data: puzzles } = await supabase
     .from('puzzles')
     .select('id, chainId, name, author:users(*), numberSolved, addedTimestamp')
-    .not('isEvent', 'is', excludeEvents)
     .not('address', 'is', null)
+    .not('eventId', 'is', excludeEvents ? null : undefined)
     .order('addedTimestamp', { ascending: true })
     .returns<Required<PuzzleSolve>['puzzle'][]>();
 

--- a/lib/utils/fetchLeaderboardPuzzles.ts
+++ b/lib/utils/fetchLeaderboardPuzzles.ts
@@ -8,6 +8,7 @@ import type { Phase, PuzzleSolve, PuzzleSolver } from '@/lib/types/protocol';
 export type LeaderboardPuzzlesResponse = {
   data: {
     data: PuzzleSolver[];
+    puzzles: number;
     solvers: number;
     solves: number;
     filter: string;
@@ -44,7 +45,7 @@ const fetchLeaderboardPuzzles = async ({
 
   if ((error && status !== 406) || !data || (data && data.length === 0)) {
     return {
-      data: { data: [], solvers: 0, solves: 0, filter },
+      data: { data: [], puzzles: 0, solvers: 0, solves: 0, filter },
       status,
       error,
     };
@@ -149,6 +150,7 @@ const fetchLeaderboardPuzzles = async ({
     data: {
       // Return the top 100 solvers w/ rank.
       data: solvers.slice(0, 100).map((item, index) => ({ ...item, rank: index + 1 })),
+      puzzles: puzzleMap.size,
       solvers: solvers.length,
       solves: filteredData.length,
       filter,

--- a/lib/utils/fetchPuzzleById.ts
+++ b/lib/utils/fetchPuzzleById.ts
@@ -61,7 +61,6 @@ const fetchPuzzleById = async (id: number, chainId: number): Promise<PuzzleRespo
     solution: puzzleData.solution,
     github: puzzleData.github,
     disabled: puzzleData.disabled,
-    isEvent: puzzleData.isEvent,
     // Puzzle source code
     bytecode: puzzleData.bytecode,
     solidity: puzzleData.solidity,

--- a/lib/utils/fetchPuzzles.ts
+++ b/lib/utils/fetchPuzzles.ts
@@ -43,7 +43,6 @@ const fetchPuzzles = async (): Promise<PuzzlesResponse> => {
       solution: puzzle.solution,
       github: puzzle.github,
       disabled: puzzle.disabled,
-      isEvent: puzzle.isEvent,
       // Puzzle source code
       bytecode: puzzle.bytecode,
       solidity: puzzle.solidity,

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,4 +1,5 @@
 import fetchAuthors from './fetchAuthors';
+import fetchEvents from './fetchEvents';
 import fetchLeaderboardPuzzles from './fetchLeaderboardPuzzles';
 import fetchPuzzleById from './fetchPuzzleById';
 import fetchPuzzleFlagColors from './fetchPuzzleFlagColors';
@@ -17,6 +18,7 @@ import getTimeLeftString from './getTimeLeftString';
 
 export {
   fetchAuthors,
+  fetchEvents,
   fetchLeaderboardPuzzles,
   fetchPuzzleById,
   fetchPuzzleFlagColors,


### PR DESCRIPTION
- [x] Refactor Puzzles leaderboard filter search param from `puzzles-season` $\rightarrow$ `filter`
- [x] Makes Puzzles leaderboard filtering more generic:
  - [x] `all`: Include all puzzles except `isEvent: true` puzzles.
  - [x] `season`: Include all puzzles from the parsed season number. In the form of `season_${seasonNumber}`. If the parsed season number is not a valid season number, set the default season to the latest season.
  - [x] `event`: Include all puzzles from the parsed event number. In the form `event_${eventSlug}`. If the parsed event slug is not a valid event slug, set the default event as the latest event.
- [x] Display number of puzzles in the selected filter, rather than start and finishing ID
- [x] Add event leaderboard (no teams support in this PR)
- [x] Refactor/fix data fetching to accommodate all filter types

> **Note** The default filter (i.e. when the `filter` search param is invalid/not provided) will still be the latest season; may want to update this.