### PR TITLE
fix: default puzzles count, puzzles included in seasons, etc.

### DIFF
--- a/app/leaderboard/(components)/puzzles/content.tsx
+++ b/app/leaderboard/(components)/puzzles/content.tsx
@@ -235,7 +235,7 @@ const LeaderboardPuzzlesContent: FC<LeaderboardPuzzlesContentProps> = ({
                               )
                             ) : null}
                             <span className="w-fit whitespace-nowrap">
-                              {`${data?.puzzles ?? 5} puzzles`}
+                              {`${data?.puzzles ?? defaultData.puzzles} puzzles`}
                             </span>
                           </Fragment>
                         ),

--- a/app/leaderboard/(components)/puzzles/index.tsx
+++ b/app/leaderboard/(components)/puzzles/index.tsx
@@ -29,16 +29,16 @@ const LeaderboardPuzzles: FC<LeaderboardPuzzlesProps> = async ({ puzzles }) => {
   if (events.length > 0 && events[events.length - 1].endDate > Date.now() / 1000) {
     // If the latest event is still ongoing, make the default season the event.
     const { data } = await fetchLeaderboardPuzzles({
-      minPuzzleIndex: 1,
-      maxPuzzleIndex: Number.MAX_SAFE_INTEGER,
+      minPuzzleIndex: 0,
+      maxPuzzleIndex: Number.MAX_SAFE_INTEGER - 1,
       filter: `event_${events[events.length - 1].slug}`,
       eventSlug: events[events.length - 1].slug,
     });
     defaultData = data;
     defaultFilter = `event_${events[events.length - 1].slug}`;
   } else {
-    const minPuzzleIndex = (maxSeason - 1) * 5 + 1;
-    const maxPuzzleIndex = Math.min(puzzles, maxSeason * 5);
+    const minPuzzleIndex = (maxSeason - 1) * 5;
+    const maxPuzzleIndex = Math.min(puzzles, maxSeason * 5) - 1;
 
     // Otherwise, default to the latest season.
     const { data } = await fetchLeaderboardPuzzles({

--- a/app/leaderboard/(components)/puzzles/server-action.ts
+++ b/app/leaderboard/(components)/puzzles/server-action.ts
@@ -7,14 +7,14 @@ import { fetchLeaderboardPuzzles } from '@/lib/utils';
 export default async function action(filter: LeaderboardPuzzlesFilterAndValue, puzzles: number) {
   if (filter.type === 'all') {
     return await fetchLeaderboardPuzzles({
-      minPuzzleIndex: 1,
-      maxPuzzleIndex: Number.MAX_SAFE_INTEGER,
+      minPuzzleIndex: 0,
+      maxPuzzleIndex: Number.MAX_SAFE_INTEGER - 1,
       filter: 'all',
       excludeEvents: true,
     });
   } else if (filter.type === 'season') {
-    const minPuzzleIndex = (filter.value - 1) * 5 + 1;
-    const maxPuzzleIndex = Math.min(puzzles, filter.value * 5);
+    const minPuzzleIndex = (filter.value - 1) * 5;
+    const maxPuzzleIndex = Math.min(puzzles, filter.value * 5) - 1;
 
     return await fetchLeaderboardPuzzles({
       minPuzzleIndex,
@@ -24,8 +24,8 @@ export default async function action(filter: LeaderboardPuzzlesFilterAndValue, p
   }
 
   return await fetchLeaderboardPuzzles({
-    minPuzzleIndex: 1,
-    maxPuzzleIndex: Number.MAX_SAFE_INTEGER,
+    minPuzzleIndex: 0,
+    maxPuzzleIndex: Number.MAX_SAFE_INTEGER - 1,
     filter: `event_${filter.value}`,
     eventSlug: filter.value,
   });

--- a/lib/utils/fetchLeaderboardPuzzles.ts
+++ b/lib/utils/fetchLeaderboardPuzzles.ts
@@ -71,8 +71,8 @@ const fetchLeaderboardPuzzles = async ({
     // range.
     if (
       (excludeEvents && puzzle.eventId) ||
-      puzzle.id < minPuzzleIndex ||
-      puzzle.id > maxPuzzleIndex ||
+      index + 1 < minPuzzleIndex ||
+      index + 1 > maxPuzzleIndex ||
       (eventSlug && puzzle.eventId?.slug !== eventSlug)
     ) {
       return;

--- a/lib/utils/fetchLeaderboardPuzzles.ts
+++ b/lib/utils/fetchLeaderboardPuzzles.ts
@@ -71,8 +71,8 @@ const fetchLeaderboardPuzzles = async ({
     // range.
     if (
       (excludeEvents && puzzle.eventId) ||
-      index + 1 < minPuzzleIndex ||
-      index + 1 > maxPuzzleIndex ||
+      index < minPuzzleIndex ||
+      index > maxPuzzleIndex ||
       (eventSlug && puzzle.eventId?.slug !== eventSlug)
     ) {
       return;


### PR DESCRIPTION
- [x] Fix default puzzles count (instead of falling back to `5`)
- [x] Include puzzles by puzzle index, not puzzle ID
- [x] Refactor `minPuzzleIndex` and `maxPuzzleIndex` to be 0-indexed (from being 1-indexed)