### PR TITLE
Remove 1-step submission from Golf Courses

### DIFF
--- a/app/golf/[slug]/(components)/info/leader.tsx
+++ b/app/golf/[slug]/(components)/info/leader.tsx
@@ -29,7 +29,7 @@ const CourseInfoLeader: React.FC<CourseInfoLeaderProps> = ({ course }) => {
         >
           <div className="text-center text-sm font-book text-[#09491E]">King of the Hill</div>
           <AddressLinkClient
-            className="text-2xl font-medium text-gray-50"
+            className="text-2xl font-medium text-gray-50 hover:text-gray-50"
             address={course.leader.address as `0x${string}`}
           />
           <ExternalLink className="absolute right-2 top-2 h-3 w-3 text-[#09491E]" />

--- a/app/golf/[slug]/(components)/info/solution-form/2-step-flow.tsx
+++ b/app/golf/[slug]/(components)/info/solution-form/2-step-flow.tsx
@@ -53,75 +53,69 @@ const CourseInfoSolutionForm2StepFlow: React.FC<CourseInfoSolutionForm2StepFlowP
   const waitOver = commitMade && 60 + commitTimestamp - Date.now() / 1000 <= 0;
 
   return (
-    <div className="flex w-full items-center justify-center rounded-b-lg border border-stroke p-2">
-      <div className="relative flex w-full items-center justify-between rounded-lg bg-gray-450 px-4 py-3">
-        <svg
-          // We do `left-9` here because we have 16px of left-padding on the
-          // parent, 12px of space required to start from the center of the
-          // circle, and finally about 8px offset because of the label text (16
-          // + 12 + 8 = 36).
-          className="absolute left-9 top-[23px]"
-          xmlns="http://www.w3.org/2000/svg"
-          height="2"
-          fill="none"
-          role="figure"
-          style={{ width: 'calc(50% - 36px)' }}
-        >
-          <line
-            className={clsx(
-              'transition-[stroke-dasharray,stroke-color',
-              commitMade ? 'stroke-blue-250' : 'stroke-stroke',
-            )}
-            x1="1"
-            y1="1"
-            x2="999" /* Some arbitrary value greater than the max reasonable value. */
-            y2="1"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeDasharray={commitMade ? undefined : '4 4'}
-          />
-        </svg>
-        <svg
-          // We can do `left-1/2` here because the center "step" circle is
-          // perfectly centered within the circle. See comments for the previous
-          // SVG for `top-[23px]`.
-          className="absolute left-1/2 top-[23px]"
-          xmlns="http://www.w3.org/2000/svg"
-          height="2"
-          fill="none"
-          role="figure"
-          style={{ width: 'calc(50% - 36px)' }}
-        >
-          <line
-            className={clsx(
-              'transition-[stroke-dasharray,stroke-color',
-              waitOver ? 'stroke-blue-250' : 'stroke-stroke',
-            )}
-            x1="1"
-            y1="1"
-            x2="999" /* Some arbitrary value greater than the max reasonable value. */
-            y2="1"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeDasharray={waitOver ? undefined : '4 4'}
-          />
-        </svg>
-        <div className="flex flex-col items-center gap-1">
-          <Step state={commitMade ? 'completed' : 'pending'} />
-          <div className="text-xs text-gray-100">Commit</div>
-        </div>
-        <div className="absolute left-0 right-0 flex flex-col items-center gap-1">
-          <Countdown commitTimestamp={commitTimestamp} />
-          <div className={clsx('text-xs', commitMade ? 'text-gray-100' : 'text-gray-200')}>
-            Wait
-          </div>
-        </div>
-        <div className="flex flex-col items-center gap-1">
-          <Step state={waitOver ? 'pending' : 'none'} />
-          <div className={clsx('text-xs', waitOver ? 'text-gray-100' : 'text-gray-200')}>
-            Reveal
-          </div>
-        </div>
+    <div className="relative flex w-full items-center justify-between rounded-lg border border-stroke bg-gray-450 px-4 py-3">
+      <svg
+        // We do `left-9` here because we have 16px of left-padding on the
+        // parent, 12px of space required to start from the center of the
+        // circle, and finally about 8px offset because of the label text (16
+        // + 12 + 8 = 36).
+        className="absolute left-9 top-[23px]"
+        xmlns="http://www.w3.org/2000/svg"
+        height="2"
+        fill="none"
+        role="figure"
+        style={{ width: 'calc(50% - 36px)' }}
+      >
+        <line
+          className={clsx(
+            'transition-[stroke-dasharray,stroke-color',
+            commitMade ? 'stroke-blue-250' : 'stroke-stroke',
+          )}
+          x1="1"
+          y1="1"
+          x2="999" /* Some arbitrary value greater than the max reasonable value. */
+          y2="1"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeDasharray={commitMade ? undefined : '4 4'}
+        />
+      </svg>
+      <svg
+        // We can do `left-1/2` here because the center "step" circle is
+        // perfectly centered within the circle. See comments for the previous
+        // SVG for `top-[23px]`.
+        className="absolute left-1/2 top-[23px]"
+        xmlns="http://www.w3.org/2000/svg"
+        height="2"
+        fill="none"
+        role="figure"
+        style={{ width: 'calc(50% - 36px)' }}
+      >
+        <line
+          className={clsx(
+            'transition-[stroke-dasharray,stroke-color',
+            waitOver ? 'stroke-blue-250' : 'stroke-stroke',
+          )}
+          x1="1"
+          y1="1"
+          x2="999" /* Some arbitrary value greater than the max reasonable value. */
+          y2="1"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeDasharray={waitOver ? undefined : '4 4'}
+        />
+      </svg>
+      <div className="flex flex-col items-center gap-1">
+        <Step state={commitMade ? 'completed' : 'pending'} />
+        <div className="text-xs text-gray-100">Commit</div>
+      </div>
+      <div className="absolute left-0 right-0 flex flex-col items-center gap-1">
+        <Countdown commitTimestamp={commitTimestamp} />
+        <div className={clsx('text-xs', commitMade ? 'text-gray-100' : 'text-gray-200')}>Wait</div>
+      </div>
+      <div className="flex flex-col items-center gap-1">
+        <Step state={waitOver ? 'pending' : 'none'} />
+        <div className={clsx('text-xs', waitOver ? 'text-gray-100' : 'text-gray-200')}>Reveal</div>
       </div>
     </div>
   );

--- a/app/golf/[slug]/(components)/info/solution-form/index.tsx
+++ b/app/golf/[slug]/(components)/info/solution-form/index.tsx
@@ -1,30 +1,17 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 
 import type { GolfCourseValue } from '../../types';
 import CourseInfoSolutionForm2StepFlow from './2-step-flow';
 import CourseInfoSolutionForm2StepSubmitButton from './2-step-submit';
 import CourseInfoSolutionFormOpcodesAccordion from './opcodes-accordion';
-import * as RadioGroup from '@radix-ui/react-radio-group';
-import clsx from 'clsx';
-import { AlertCircle, ArrowDown, CheckCircle, Circle, Crown, ExternalLink } from 'lucide-react';
+import { ArrowDown } from 'lucide-react';
 import { isHex } from 'viem';
-import {
-  useAccount,
-  useContractWrite,
-  useNetwork,
-  usePrepareContractWrite,
-  useSwitchNetwork,
-  useWaitForTransaction,
-} from 'wagmi';
-
-import { CURTA_GOLF_ABI } from '@/lib/constants/abi';
-import { getChainInfo } from '@/lib/utils';
+import { useNetwork, useSwitchNetwork } from 'wagmi';
 
 import ConnectButton from '@/components/common/connect-button';
-import { Callout } from '@/components/templates/mdx';
-import { Button, Input, Tooltip, useToast } from '@/components/ui';
+import { Button, Input } from '@/components/ui';
 
 // -----------------------------------------------------------------------------
 // Props
@@ -41,122 +28,13 @@ type CourseInfoSolutionFormProps = {
 const CourseInfoSolutionForm: React.FC<CourseInfoSolutionFormProps> = ({ course }) => {
   const [mounted, setMounted] = useState<boolean>(false);
   const [submission, setSubmission] = useState<string>('');
-  const [submissionMethod, setSubmissionMethod] = useState<string>();
-  const { toast } = useToast();
   const { chain } = useNetwork();
-  const { address } = useAccount();
   const { switchNetwork } = useSwitchNetwork();
 
   // Set `mounted` to true on page load.
   useEffect(() => setMounted(true), []);
 
-  // ---------------------------------------------------------------------------
-  // `submitDirectly` simulation and preparation
-  // ---------------------------------------------------------------------------
-
-  const {
-    config: simulation,
-    isLoading: simulationIsLoading,
-    isError: simulationIsError,
-  } = usePrepareContractWrite({
-    address: getChainInfo(course.chainId).golf,
-    abi: CURTA_GOLF_ABI,
-    functionName: 'submitDirectly',
-    // We use the connected address as a dummy value for `recipient`, or if
-    // there is no connected address, we use a dummy `address(1)` to prevent the
-    // mint from reverting.
-    args: [course.id, submission, address ?? '0x0000000000000000000000000000000000000001'],
-    chainId: course.chainId,
-  });
-
-  // ---------------------------------------------------------------------------
-  // `submitDirectly` transaction (only relevant for 1-step method)
-  // ---------------------------------------------------------------------------
-
-  const { data: submitDirectlyData, write: submitDirectly } = useContractWrite({
-    ...simulation,
-    onError: (error) =>
-      toast({ intent: 'fail', title: 'Transaction error', description: error?.message }),
-    onSuccess: (data) =>
-      toast({
-        title: 'Transaction sent',
-        description: 'Your transaction has been sent.',
-        intent: 'primary',
-        action: (
-          <Button
-            size="sm"
-            href={`https://${getChainInfo(course.chainId).blockExplorer}/tx/${data.hash}`}
-            rightIcon={<ExternalLink />}
-            intent="primary"
-            newTab
-          >
-            View
-          </Button>
-        ),
-      }),
-  });
-  const { isLoading: submitDirectlyIsLoading } = useWaitForTransaction({
-    hash: submitDirectlyData?.hash,
-    onError(error) {
-      toast({
-        title: 'Transaction fail',
-        description: error.message,
-        intent: 'fail',
-        action: submitDirectlyData ? (
-          <Button
-            size="sm"
-            href={`https://${getChainInfo(course.chainId).blockExplorer}/tx/${
-              submitDirectlyData.hash
-            }`}
-            rightIcon={<ExternalLink />}
-            intent="fail"
-            newTab
-          >
-            View
-          </Button>
-        ) : undefined,
-      });
-    },
-    onSuccess(data) {
-      toast({
-        title: 'Submitted directly',
-        description: 'Bytecode successfully submitted!',
-        intent: 'success',
-        action: data ? (
-          <Button
-            size="sm"
-            href={`https://${getChainInfo(course.chainId).blockExplorer}/tx/${
-              data.transactionHash
-            }`}
-            rightIcon={<ExternalLink />}
-            intent="success"
-            newTab
-          >
-            View
-          </Button>
-        ) : undefined,
-      });
-    },
-  });
-
-  const isSubmissionValid = submission.length > 0 && isHex(submission) && !simulationIsError;
-  const toBeLeader =
-    isSubmissionValid &&
-    (course.leaderGas
-      ? typeof simulation?.result === 'number' && simulation.result < course.leaderGas
-      : true);
-
-  // If the submission is valid, we set the submission method to 1-step by
-  // default, and if it's both valid and to be the leading solution, we set the
-  // submission method to 2-step by default. Otherwise, we clear the radio
-  // selection.
-  useEffect(() => {
-    if (isSubmissionValid) {
-      setSubmissionMethod(toBeLeader ? 'sm1' : 'sm0');
-    } else {
-      setSubmissionMethod(undefined);
-    }
-  }, [isSubmissionValid, toBeLeader]);
+  const isSubmissionValid = submission.length > 0 && isHex(submission);
 
   return (
     <div className="flex w-full flex-col items-center gap-3 p-4">
@@ -175,7 +53,7 @@ const CourseInfoSolutionForm: React.FC<CourseInfoSolutionFormProps> = ({ course 
           pattern="^0x[0-9a-fA-F]*$"
           errorMessage="Bytecode must be a hex-string"
         />
-        <div className="flex w-full items-center justify-between text-sm">
+        {/* <div className="flex w-full items-center justify-between text-sm">
           <div className="flex items-center gap-1 pl-[15px]">
             <div className="stroke-stroke leading-4">
               <svg
@@ -220,73 +98,20 @@ const CourseInfoSolutionForm: React.FC<CourseInfoSolutionFormProps> = ({ course 
               <div className="h-4 w-10 animate-pulse rounded-md bg-gray-350" />
             </div>
           )}
-        </div>
-        <div className="relative flex h-6 w-full items-center justify-center" role="separator">
-          <hr className="w-full border-t border-stroke" />
-          <div className="absolute top-0 mx-0 flex h-6 w-6 items-center justify-center rounded-full bg-gray-450 text-gray-200 ring-4 ring-gray-600">
-            <ArrowDown className="h-3 w-3" />
-          </div>
-        </div>
-        <div className="flex w-full flex-col gap-2">
-          <div className="flex w-full flex-col gap-1">
-            <label htmlFor="submission-method" className="text-xs text-gray-200">
-              Submission method
-            </label>
-            <RadioGroup.Root
-              id="submission-method"
-              className={clsx(
-                'flex w-full flex-col -space-y-[1px]',
-                !isSubmissionValid ? 'cursor-not-allowed text-gray-200' : 'text-gray-100',
-              )}
-              value={submissionMethod}
-              onValueChange={(value) => setSubmissionMethod(value)}
-              disabled={!isSubmissionValid}
-            >
-              {['1-step', '2-step (prevent frontrunning)'].map((value, i) => (
-                <div
-                  key={i}
-                  className={clsx(
-                    'z-[1] flex h-9 items-center gap-1.5 border border-stroke px-3 transition-colors first:rounded-t-lg last:rounded-b-lg hover:z-[2]',
-                    isSubmissionValid ? 'hover:border-gray-300' : '',
-                  )}
-                >
-                  <RadioGroup.Item
-                    value={`sm${i}`}
-                    id={`r-sm${i}`}
-                    className={clsx(
-                      'flex h-4 w-4 items-center justify-center rounded-full border border-stroke focus:outline-none',
-                      isSubmissionValid
-                        ? 'transition-colors hover:border-gray-300 focus-visible:ring-1 focus-visible:ring-blue-250'
-                        : 'cursor-not-allowed',
-                    )}
-                    disabled={!isSubmissionValid}
-                  >
-                    <RadioGroup.Indicator className="flex items-center justify-center">
-                      <Circle className="h-2.5 w-2.5 fill-blue-250 text-blue-250" />
-                    </RadioGroup.Indicator>
-                  </RadioGroup.Item>
-                  <label
-                    className={clsx(
-                      'grow text-sm font-medium',
-                      isSubmissionValid ? 'cursor-pointer' : 'cursor-not-allowed',
-                    )}
-                    htmlFor={`r-sm${i}`}
-                  >
-                    {value}
-                  </label>
-                </div>
-              ))}
-              {submissionMethod === 'sm1' && isHex(submission) ? (
-                <CourseInfoSolutionForm2StepFlow bytecode={submission} chainId={course.chainId} />
-              ) : null}
-            </RadioGroup.Root>
-          </div>
-          {toBeLeader && submissionMethod === 'sm0' ? (
-            <Callout className="my-0" size="sm" intent="warning">
-              Your solution may get frontrun.
-            </Callout>
-          ) : null}
-        </div>
+        </div> */}
+        {isHex(submission) ? (
+          <Fragment>
+            <div className="relative flex h-6 w-full items-center justify-center" role="separator">
+              <hr className="w-full border-t border-stroke" />
+              <div className="absolute top-0 mx-0 flex h-6 w-6 items-center justify-center rounded-full bg-gray-450 text-gray-200 ring-4 ring-gray-600">
+                <ArrowDown className="h-3 w-3" />
+              </div>
+            </div>
+            <div className="flex w-full flex-col gap-2">
+              <CourseInfoSolutionForm2StepFlow bytecode={submission} chainId={course.chainId} />
+            </div>
+          </Fragment>
+        ) : null}
       </div>
       {!chain || !mounted ? (
         <ConnectButton className="w-full" />
@@ -298,20 +123,6 @@ const CourseInfoSolutionForm: React.FC<CourseInfoSolutionFormProps> = ({ course 
           onClick={() => switchNetwork?.(course.chainId)}
         >
           Switch network
-        </Button>
-      ) : submissionMethod === 'sm0' ? (
-        /* 1-step submission button */
-        <Button
-          type="submit"
-          className="w-full"
-          size="lg"
-          onClick={(e) => {
-            e.preventDefault();
-            submitDirectly?.();
-          }}
-          disabled={submission.length === 0 || !submitDirectly || submitDirectlyIsLoading}
-        >
-          Submit
         </Button>
       ) : isHex(submission) && isSubmissionValid ? (
         /* 2-step submission button */

--- a/lib/constants/abi.ts
+++ b/lib/constants/abi.ts
@@ -663,8 +663,8 @@ export const CURTA_GOLF_ABI = [
   },
   {
     inputs: [
-      { internalType: 'address', name: 'spender', type: 'address' },
-      { internalType: 'uint256', name: 'id', type: 'uint256' },
+      { internalType: 'address', name: '_spender', type: 'address' },
+      { internalType: 'uint256', name: '_id', type: 'uint256' },
     ],
     name: 'approve',
     outputs: [],
@@ -672,7 +672,7 @@ export const CURTA_GOLF_ABI = [
     type: 'function',
   },
   {
-    inputs: [{ internalType: 'address', name: 'owner', type: 'address' }],
+    inputs: [{ internalType: 'address', name: '_owner', type: 'address' }],
     name: 'balanceOf',
     outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
     stateMutability: 'view',
@@ -729,6 +729,23 @@ export const CURTA_GOLF_ABI = [
     type: 'function',
   },
   {
+    inputs: [{ internalType: 'uint256', name: '_id', type: 'uint256' }],
+    name: 'getTokenData',
+    outputs: [
+      {
+        components: [
+          { internalType: 'address', name: 'owner', type: 'address' },
+          { internalType: 'uint96', name: 'metadata', type: 'uint96' },
+        ],
+        internalType: 'struct KingERC721.TokenData',
+        name: 'tokenData',
+        type: 'tuple',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
     inputs: [
       { internalType: 'address', name: '', type: 'address' },
       { internalType: 'address', name: '', type: 'address' },
@@ -753,7 +770,7 @@ export const CURTA_GOLF_ABI = [
     type: 'function',
   },
   {
-    inputs: [{ internalType: 'uint256', name: 'id', type: 'uint256' }],
+    inputs: [{ internalType: 'uint256', name: '_id', type: 'uint256' }],
     name: 'ownerOf',
     outputs: [{ internalType: 'address', name: 'owner', type: 'address' }],
     stateMutability: 'view',
@@ -775,9 +792,9 @@ export const CURTA_GOLF_ABI = [
   },
   {
     inputs: [
-      { internalType: 'address', name: 'from', type: 'address' },
-      { internalType: 'address', name: 'to', type: 'address' },
-      { internalType: 'uint256', name: 'id', type: 'uint256' },
+      { internalType: 'address', name: '_from', type: 'address' },
+      { internalType: 'address', name: '_to', type: 'address' },
+      { internalType: 'uint256', name: '_id', type: 'uint256' },
     ],
     name: 'safeTransferFrom',
     outputs: [],
@@ -786,10 +803,10 @@ export const CURTA_GOLF_ABI = [
   },
   {
     inputs: [
-      { internalType: 'address', name: 'from', type: 'address' },
-      { internalType: 'address', name: 'to', type: 'address' },
-      { internalType: 'uint256', name: 'id', type: 'uint256' },
-      { internalType: 'bytes', name: 'data', type: 'bytes' },
+      { internalType: 'address', name: '_from', type: 'address' },
+      { internalType: 'address', name: '_to', type: 'address' },
+      { internalType: 'uint256', name: '_id', type: 'uint256' },
+      { internalType: 'bytes', name: '_data', type: 'bytes' },
     ],
     name: 'safeTransferFrom',
     outputs: [],
@@ -808,8 +825,8 @@ export const CURTA_GOLF_ABI = [
   },
   {
     inputs: [
-      { internalType: 'address', name: 'operator', type: 'address' },
-      { internalType: 'bool', name: 'approved', type: 'bool' },
+      { internalType: 'address', name: '_operator', type: 'address' },
+      { internalType: 'bool', name: '_approved', type: 'bool' },
     ],
     name: 'setApprovalForAll',
     outputs: [],
@@ -836,21 +853,10 @@ export const CURTA_GOLF_ABI = [
     type: 'function',
   },
   {
-    inputs: [
-      { internalType: 'uint32', name: '_courseId', type: 'uint32' },
-      { internalType: 'bytes', name: '_solution', type: 'bytes' },
-      { internalType: 'address', name: '_recipient', type: 'address' },
-    ],
-    name: 'submitDirectly',
-    outputs: [{ internalType: 'uint32', name: '', type: 'uint32' }],
-    stateMutability: 'nonpayable',
-    type: 'function',
-  },
-  {
-    inputs: [{ internalType: 'bytes4', name: 'interfaceId', type: 'bytes4' }],
+    inputs: [{ internalType: 'bytes4', name: '_interfaceId', type: 'bytes4' }],
     name: 'supportsInterface',
     outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
-    stateMutability: 'view',
+    stateMutability: 'pure',
     type: 'function',
   },
   {
@@ -869,9 +875,9 @@ export const CURTA_GOLF_ABI = [
   },
   {
     inputs: [
-      { internalType: 'address', name: 'from', type: 'address' },
-      { internalType: 'address', name: 'to', type: 'address' },
-      { internalType: 'uint256', name: 'id', type: 'uint256' },
+      { internalType: 'address', name: '_from', type: 'address' },
+      { internalType: 'address', name: '_to', type: 'address' },
+      { internalType: 'uint256', name: '_id', type: 'uint256' },
     ],
     name: 'transferFrom',
     outputs: [],


### PR DESCRIPTION
## Description
This PR removes the 1-step submission (via `CurtaGolf.submitDirectly`).

> [!NOTE]
> We were previously simulating whether the bytecode was a valid solution and metering the gas by using a prepared contract write w/ `submitDirectly`. This is no longer easily possible, so user inputs no longer get checked. To mitigate the effects, a `<Callout intent="warning" />` is presented and the submission bytecode is checked to not contain any invalid opcodes.